### PR TITLE
Fixes

### DIFF
--- a/src/helpers/log-missing.js
+++ b/src/helpers/log-missing.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = (latest, missing, previousVersion, { data: { root } }) => {
+  const { contentCatalog } = root
+  if (!contentCatalog || !missing) return
+  console.warn(`${previousVersion} does not exist in ${latest.version}`)
+}

--- a/src/partials/contributors-modal.hbs
+++ b/src/partials/contributors-modal.hbs
@@ -18,15 +18,15 @@
             <span>Edit on GitHub</span>
           </a>
         {{/if}}
+        <p>Or, let us know about something that you want us to change:</p>
+        {{#with (get-page-info page.url)}}
+        <a href="{{this.webUrl}}/issues/new?title=Docs: Feedback for {{this.title}}&template=01_doc_request.yml&link=[{{this.title}}]({{@root.site.url}}{{this.url}}) [Page source]({{this.editUrl}})" target="_blank" rel="noopener noreferrer"><span>Open an issue</span></a>
+        {{/with}}
       </div>
       <div class="modal-column">
         <h3>Contributing guide</h3>
         <p>For extensive content updates, or if you prefer to work locally:</p>
         <a href="https://github.com/redpanda-data/docs-site/blob/main/meta-docs/CONTRIBUTING.adoc" target="_blank" rel="noopener noreferrer"><span>See the contributing guide</span></a>
-        <p>Or, to let us know about something that you want us to change:</p>
-        {{#with (get-page-info page.url)}}
-        <a href="{{this.webUrl}}/issues/new?title=Docs: Feedback for {{{this.title}}}&body=Hi, I have some feedback about [this page]({{{this.editUrl}}})%0D%0A" target="_blank" rel="noopener noreferrer"><span>Open an issue</span></a>
-        {{/with}}
       </div>
     </div>
   </div>

--- a/src/partials/latest-banner.hbs
+++ b/src/partials/latest-banner.hbs
@@ -1,13 +1,7 @@
 {{#unless (or (ne page.attributes.hide-view-latest undefined) (eq page.componentVersion page.component.latest))}}
 {{#with page.latest}}
-{{#if ./missing}}
-  {{#if (and @root.page.componentVersion.prerelease (not ./prerelease))}}
-  <div class="doc banner-container" id="latest-banner">
-    <div>You are viewing the documentation for a prerelease version.
-    </div>
-  </div>
-  {{/if}}
-{{else}}
+{{#with (log-missing this ./missing @root.page.url)}}
+{{/with}}
 <div class="doc banner-container" id="latest-banner">
   {{#if (and @root.page.componentVersion.prerelease (not ./prerelease))}}
     <div>You are viewing the documentation for a prerelease version.
@@ -25,6 +19,5 @@
     For up-to-date documentation, see the <a href="{{relativize ./url}}">latest version</a> ({{@root.page.component.latest.version}}).
   </div>
 </div>
-{{/if}}
 {{/with}}
 {{/unless}}


### PR DESCRIPTION
- Always display banners on pages of non-latest versions.
- Log pages in previous versions that are missing in the latest version.
- Autofill issue template using URL query parameters