### PR TITLE
Style nav tree and admonitions

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -377,6 +377,8 @@
   margin: 1.4rem 0 0;
   box-shadow: var(--admonition-border-box-shadow);
   padding: var(--admonition-padding);
+  position: relative;
+  z-index: -1;
 }
 
 .doc .admonitionblock.note {
@@ -420,7 +422,7 @@
 }
 
 .doc .admonitionblock pre {
-  font-size: calc(18 / var(--rem-base) * 1rem);
+  font-size: calc(16 / var(--rem-base) * 1rem);
 }
 
 .doc .admonitionblock > table {

--- a/src/css/nav.css
+++ b/src/css/nav.css
@@ -152,7 +152,7 @@ html.is-clipped--nav {
   min-height: 30px;
   justify-content: space-between;
   align-items: center;
-  margin-top: 5px;
+  margin-top: 2px;
   border-radius: 3px;
 }
 


### PR DESCRIPTION
- Reduced the distance between items in the nav tree to better match the existing Redpanda docs.
- Gave admonitions a z-index of -1 so that the page version selector is always displayed above it.
- Reduced the font size of pre elements in admonitions to match regular text.