### PR TITLE
Check for existence of image

### DIFF
--- a/src/partials/algolia-script.hbs
+++ b/src/partials/algolia-script.hbs
@@ -45,7 +45,7 @@ window.addEventListener('DOMContentLoaded', function() {
           ? html`<div class="aa-Preview aa-Column doc">
             <div class="aa-PanelLayout aa-Panel--scrollable">
               ${
-                preview.image.src
+                preview.image
                 ? html`<div class="aa-ItemIcon">
                         <img
                           src="${preview.image.src}"


### PR DESCRIPTION
Fixes a bug where if the `image` property doesn't exist, we get errors in the console.