### PR TITLE
Fix callouts

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -170,7 +170,6 @@
   color: var(--code-font-color);
   background: var(--code-background);
   border-radius: 0.25em;
-  box-shadow: 0 1px 2px 0 #0000001a;
   font-size: 0.88rem;
   padding: 0.125em 0.25em;
 }

--- a/src/partials/editable-placeholders-script.hbs
+++ b/src/partials/editable-placeholders-script.hbs
@@ -42,11 +42,12 @@ function addConumSpans(element) {
   if (!element || !element.textContent) {
       return;
   }
-  let codeContent = element.innerText;
+  let codeContent = element.innerHTML;
 
   // Find numbers inside brackets at the end of lines
-  let pattern = /\((\d+)\)\s*$/gm;
+  let pattern = /<span class="token punctuation">\(<\/span><span class="token number">(\d+)<\/span><span class="token punctuation">\)<\/span>\s*$/gm;
   let replaced = codeContent.replace(pattern, '<i class="conum" data-value="$1"></i>');
+  console.log(replaced)
   element.innerHTML = replaced;
 }
 

--- a/src/partials/editable-placeholders-script.hbs
+++ b/src/partials/editable-placeholders-script.hbs
@@ -4,6 +4,7 @@ function createEditablePlaceholders () {
 
   for (let i = 0; i < codeElements.length; i++) {
     const codeElement = codeElements[i];
+    addConumSpans(codeElement);
     if(codeElement.dataset.lang !== 'xml' && codeElement.dataset.lang !== 'html') {
       addEditableSpan(/&lt;.[^&A-Z]*&gt;/g, codeElement);
     }
@@ -35,6 +36,18 @@ function addEditableSpan(regex, element) {
     processed.add(placeholder);
   }
   element.innerHTML = newHTML;
+}
+
+function addConumSpans(element) {
+  if (!element || !element.textContent) {
+      return;
+  }
+  let codeContent = element.innerText;
+
+  // Find numbers inside brackets at the end of lines
+  let pattern = /\((\d+)\)\s*$/gm;
+  let replaced = codeContent.replace(pattern, '<i class="conum" data-value="$1"></i>');
+  element.innerHTML = replaced;
 }
 
 


### PR DESCRIPTION
Antora extracts callouts such as `<1>` in code and converts it to `<i class="conum" data-value="1"></i>` to display the numbered callouts and make sure they aren't included when you copy the code.

Since we are replacing the default code highlighter with Prism.js, these elements get removed and replaced by Prism.

This PR adds the `conum` elements back into code blocks so that callouts work and are displayed correctly.