### PR TITLE
Fix code formatting

### DIFF
--- a/src/css/dark-mode.css
+++ b/src/css/dark-mode.css
@@ -1,7 +1,7 @@
 html[data-theme=dark] {
   /* base */
   --body-background: var(--color-jet-60);
-  --panel-background: var(--body-background);
+  --panel-background: #ffffff12;
   --panel-border-color: var(--color-white);
   --scrollbar-track-color: var(--color-white);
   --scrollbar-thumb-color: var(--color-gray-10);
@@ -38,8 +38,8 @@ html[data-theme=dark] {
   --toolbar-border-color: var(--panel-border-color);
   --toolbar-font-color: var(--body-font-color);
   --toolbar-muted-color: var(--color-gray-40);
-  --page-version-menu-background: #ebedf0;
-  --page-version-font-color: var(--body-background);
+  --page-version-menu-background: #545454;
+  --page-version-font-color: var(--body-font-color);
   --page-version-missing-font-color: var(--color-gray-40);
   /* feedback */
   --feedback-modal-background: var(--body-background);

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -169,6 +169,7 @@
 .doc .colist > table code {
   color: var(--code-font-color);
   background: var(--code-background);
+  border: 0.1rem solid #0000001a;
   border-radius: 0.25em;
   font-size: 0.88rem;
   padding: 0.125em 0.25em;
@@ -189,6 +190,7 @@
 
 .doc pre > code {
   padding-bottom: 1rem;
+  border: none;
 }
 
 .doc blockquote {
@@ -880,6 +882,7 @@ code[class*=language-],
 pre[class*=language-] {
   color: var(--code-font-color) !important;
   font-size: 0.88rem !important;
+  background: var(--pre-background) !important;
 }
 
 pre.code-first-child {

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -159,7 +159,7 @@ html:not([data-theme=dark]) {
   --body-font-color: rgb(102, 112, 133);
   /* base */
   --body-background: var(--color-white);
-  --panel-background: var(--color-smoke-30);
+  --panel-background: #f9fafb;
   --panel-border-color: var(--color-smoke-90);
   --scrollbar-track-color: var(--color-smoke-30);
   --scrollbar-thumb-color: var(--color-gray-10);
@@ -254,7 +254,7 @@ html:not([data-theme=dark]) {
   --quote-attribution-font-color: var(--color-gray-40);
   --sidebar-background: var(--color-smoke-90);
   --table-border-color: var(--panel-border-color);
-  --table-stripe-background: var(--panel-background);
+  --table-stripe-background: #00000008;
   --table-footer-background: linear-gradient(to bottom, var(--color-smoke-70) 0%, var(--color-white) 100%);
   /* toc */
   --toc-font-color: var(--nav-muted-color);

--- a/src/partials/editable-placeholders-script.hbs
+++ b/src/partials/editable-placeholders-script.hbs
@@ -47,7 +47,6 @@ function addConumSpans(element) {
   // Find numbers inside brackets at the end of lines
   let pattern = /<span class="token punctuation">\(<\/span><span class="token number">(\d+)<\/span><span class="token punctuation">\)<\/span>\s*$/gm;
   let replaced = codeContent.replace(pattern, '<i class="conum" data-value="$1"></i>');
-  console.log(replaced)
   element.innerHTML = replaced;
 }
 


### PR DESCRIPTION
- Makes the `code` and `pre` background color the same.
- Updates the `code` background and the striped table background so that there's a contrast.