### PR TITLE
Update code styles and font weights

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -51,6 +51,7 @@ dt,
 strong,
 th {
   font-family: var(--body-font-family-bold);
+  font-weight: lighter;
 }
 
 sub,

--- a/src/css/dark-mode.css
+++ b/src/css/dark-mode.css
@@ -81,6 +81,7 @@ html[data-theme=dark] {
   --code-font-color: #eceff1;
   --tabs_hover-background: var(--caption-background-color);
   --editable-code-font-color: var(--link-font-color);
+  --editable-background: #323440;
   --example-background: var(--body-background);
   --example-border-color: var(--color-gray-70);
   --kbd-background: var(--panel-background);

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -171,6 +171,7 @@
   color: var(--code-font-color);
   background: var(--code-background);
   border: 0.1rem solid #0000001a;
+  font-weight: lighter;
   border-radius: 0.25em;
   font-size: 0.88rem;
   padding: 0.125em 0.25em;
@@ -192,6 +193,8 @@
 .doc pre > code {
   padding-bottom: 1rem;
   border: none;
+  white-space: pre-wrap;
+  font-weight: lighter;
 }
 
 .doc blockquote {
@@ -513,6 +516,10 @@
   color: var(--body-font-color);
   font-style: initial;
   font-weight: initial;
+}
+
+.listingblock .title > code {
+  border: none;
 }
 
 .listingblock .title {
@@ -886,6 +893,8 @@ pre[class*=language-] {
   color: var(--code-font-color) !important;
   font-size: 0.88rem !important;
   background: var(--pre-background) !important;
+  white-space: pre-wrap !important;
+  font-weight: lighter !important;
 }
 
 pre.code-first-child {

--- a/src/css/editable-placeholders.css
+++ b/src/css/editable-placeholders.css
@@ -1,11 +1,17 @@
 span.editable,
 span.editable > span {
-  font-weight: 550;
+  font-weight: 450;
   color: var(--editable-code-font-color);
+  padding: 3px;
+  border: 0.1rem solid rgba(0, 0, 0, 0.10196078431372549);
+  border-radius: 0.25rem;
+  margin-left: 1px;
+  margin-right: 1px;
+  background: var(--editable-background);
 }
 
 span.cursor {
-  left: -3px;
+  left: -9px;
   position: relative;
   display: inline-block;
   width: 4px;

--- a/src/css/typeface-calibre-medium.css
+++ b/src/css/typeface-calibre-medium.css
@@ -10,7 +10,7 @@
 
 @font-face {
   font-family: "Calibre Semibold";
-  font-style: bold;
+  font-style: normal;
   font-weight: 500;
   src:
     local("Calibre Medium"),

--- a/src/css/typeface-calibre-regular.css
+++ b/src/css/typeface-calibre-regular.css
@@ -1,6 +1,6 @@
 @font-face {
   font-family: "Calibre Regular";
-  font-weight: normal;
+  font-weight: 400;
   font-style: normal;
   src:
     local("Calibre Regular"),

--- a/src/css/typeface-ibmplexmono.css
+++ b/src/css/typeface-ibmplexmono.css
@@ -1,6 +1,16 @@
 @font-face {
   font-family: "IBM Plex Mono";
   font-style: normal;
+  font-weight: 300;
+  src:
+    local("IBM Plex Mono"),
+    url(../font/IBMPlexMono-Light.ttf) format("truetype");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "IBM Plex Mono";
+  font-style: normal;
   font-weight: 400;
   src:
     local("IBM Plex Mono"),
@@ -10,10 +20,20 @@
 
 @font-face {
   font-family: "IBM Plex Mono";
-  font-style: bold;
+  font-style: normal;
   font-weight: 500;
   src:
     local("IBM Plex Mono"),
-    url(../font/IBMPlexMono-Bold.ttf) format("truetype");
+    url(../font/IBMPlexMono-Medium.ttf) format("truetype");
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "IBM Plex Mono";
+  font-style: normal;
+  font-weight: 600;
+  src:
+    local("IBM Plex Mono"),
+    url(../font/IBMPlexMono-SemiBold.ttf) format("truetype");
   font-display: swap;
 }

--- a/src/css/typeface-roboto.css
+++ b/src/css/typeface-roboto.css
@@ -33,7 +33,7 @@
 
 @font-face {
   font-family: "Roboto";
-  font-style: italic;
+  font-style: normal;
   font-weight: 500;
   src:
     url(~@fontsource/roboto/files/roboto-latin-500-italic.woff2) format("woff2"),

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -157,7 +157,7 @@ html[data-theme=dark] {
 }
 
 html:not([data-theme=dark]) {
-  --body-font-color: black;
+  --body-font-color: #333;
   --body-faint-font-color: #667085;
   --body-footer-font-color: #98a2b3;
   /* base */

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -240,10 +240,11 @@ html:not([data-theme=dark]) {
   --caption-background-color: #f6f8fa;
   --caption-font-style: normal;
   --tabs_hover-background: #0000000d;
-  --caption-font-weight: var(--body-font-weight-bold);
+  --caption-font-weight: normal;
   --code-background: var(--panel-background);
   --code-font-color: rgb(0 0 0/1);
   --editable-code-font-color: var(--link-font-color);
+  --editable-background: #eff0f1;
   --example-background: var(--color-white);
   --example-border-color: var(--color-gray-70);
   --kbd-background: var(--panel-background);


### PR DESCRIPTION
- Added `white-space: pre-wrap` so that code is displayed how it currently is in the live site (less scrolling)
- Made code font lighter to match our current docs.
- Made the bold font weight lighter to match our current docs.
- Added a border around our editable placeholders to make them stand out without the need for an overly bold font which is distracting.