### PR TITLE
Remove top and bottom padding on editable placeholders

### DIFF
--- a/src/css/editable-placeholders.css
+++ b/src/css/editable-placeholders.css
@@ -2,7 +2,7 @@ span.editable,
 span.editable > span {
   font-weight: 450;
   color: var(--editable-code-font-color);
-  padding: 3px;
+  padding: 0 3px;
   border: 0.1rem solid rgba(0, 0, 0, 0.10196078431372549);
   border-radius: 0.25rem;
   margin-left: 1px;


### PR DESCRIPTION
If we have a few editable placeholders in a single block, they can overlap. This PR removes the top/bottom padding to avoid this.