### PR TITLE
Add extra GTM script

### DIFF
--- a/src/partials/head-scripts.hbs
+++ b/src/partials/head-scripts.hbs
@@ -1,6 +1,7 @@
 {{#with site.keys.googleAnalytics}}
 <script async src="https://www.googletagmanager.com/gtag/js?id={{this}}">
 </script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPF6N5WXMW&amp;l=dataLayer&amp;cx=c"></script>
 <script>function gtag(){dataLayer.push(arguments)};window.dataLayer=window.dataLayer||[];gtag('js',new Date());gtag('config','{{this}}')</script>
 {{/with}}
 <meta name="google-site-verification" content="QcL-pD81oJatgKXQ3Wquvk_Ku3RRtUljxKoMaicySQA" />


### PR DESCRIPTION
The Docsaurus site has two GTM scripts. The one missing in Antora must control the script injection because we aren't seeing the cookie banner in the live docs.