### PR TITLE
fix: Restack elements to fix code appearing on top of version selector

### DIFF
--- a/src/css/nav.css
+++ b/src/css/nav.css
@@ -86,7 +86,7 @@
   position: absolute;
   margin-top: 2px;
   gap: 10px;
-  z-index: 1;
+  z-index: 2;
   background-color: var(--page-version-menu-background);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   padding: 10px;

--- a/src/css/page-versions.css
+++ b/src/css/page-versions.css
@@ -5,7 +5,7 @@
   margin-top: 2.5rem;
   background-color: var(--page-version-menu-background);
   width: fit-content;
-  z-index: 0;
+  z-index: var(--z-index-page-version-menu);
 }
 
 @media screen and (min-width: 1024px) {

--- a/src/css/search.css
+++ b/src/css/search.css
@@ -55,7 +55,7 @@ article.search .versions {
   min-width: 160px;
   box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.2);
   padding: 12px 12px;
-  z-index: 1;
+  z-index: 2;
   margin-left: -5px;
   width: 100%;
   font-size: 0.875rem;

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -146,10 +146,10 @@ html[data-theme=dark] {
   --toc-width--widescreen: calc(216 / var(--rem-base) * 1rem);
   --doc-max-width: 55rem;
   /* stacking */
-  --z-index-nav: 1;
-  --z-index-toolbar: 2;
-  --z-index-page-version-menu: 3;
-  --z-index-navbar: 4;
+  --z-index-page-version-menu: 2;
+  --z-index-nav: 3;
+  --z-index-toolbar: 4;
+  --z-index-navbar: 5;
   /* Algolia */
   --aa-detached-modal-max-width: 1000px;
   --aa-spacing-factor: 1.3;


### PR DESCRIPTION
Before:

<img width="618" alt="2023-09-09_14-38-56" src="https://github.com/redpanda-data/docs-ui/assets/45230295/c4725f7a-6469-4159-9eab-7b54e699d28b">


After:

<img width="653" alt="2023-09-09_14-39-46" src="https://github.com/redpanda-data/docs-ui/assets/45230295/eca075a2-22ed-4fbf-b76e-8297bfce6c0b">
