### PR TITLE
fix: Reapply line highlights when you change tabs

### DIFF
--- a/src/css/vendor/tabs.css
+++ b/src/css/vendor/tabs.css
@@ -10,6 +10,11 @@
 
 .tablist > ul li {
   background-color: var(--body-background-color);
+  padding: 0;
+}
+
+.tablist > ul li > p {
+  padding: 0.25em 1em;
 }
 
 .doc .tabs.is-loading .tablist > ul li:not(:first-child),

--- a/src/js/10-open-nested-tabs.js
+++ b/src/js/10-open-nested-tabs.js
@@ -16,7 +16,6 @@
       const currentTab = event.target.parentElement
       const id = currentTab.id
       if (!id) return
-      const tabContent = document.getElementById(id + '--panel')
       const url = new URL(window.location.href)
       url.searchParams.set('tab', encodeURIComponent(id))
       window.history.pushState(null, null, url)

--- a/src/js/10-open-nested-tabs.js
+++ b/src/js/10-open-nested-tabs.js
@@ -1,38 +1,28 @@
+/* global Prism */
+/* global makePlaceholdersEditable */
+
 ;(function () {
   'use strict'
   window.addEventListener('DOMContentLoaded', function (event) {
     const url = new URL(window.location.href)
     const tabId = url.searchParams.get('tab')
     if (tabId) {
-      const decodedTabId = decodeURIComponent(tabId)
       this.location.hash = `#${tabId}`
-      const panel = document.querySelector(`div#${decodedTabId}--panel`)
-      if (panel) {
-        const hiddenElement = panel.querySelector('.is-hidden[hidden]')
-        if (hiddenElement) {
-          hiddenElement.classList.remove('is-hidden')
-          hiddenElement.removeAttribute('hidden')
-          hiddenElement.classList.add('is-selected')
-        }
-        const tablist = panel.querySelector('.tablist')
-        if (tablist) {
-          const firstTab = tablist.querySelector('li')
-          if (firstTab) {
-            firstTab.classList.add('is-selected')
-          }
-        }
-      }
     }
   })
-  const tabs = document.querySelectorAll('li.tab > p')
+  const tabs = document.querySelectorAll('li.tab')
   tabs.forEach(function (tab) {
     tab.addEventListener('click', function (event) {
       const currentTab = event.target.parentElement
       const id = currentTab.id
       if (!id) return
+      const tabContent = document.getElementById(id + '--panel')
       const url = new URL(window.location.href)
       url.searchParams.set('tab', encodeURIComponent(id))
       window.history.pushState(null, null, url)
+      // Rerun the line highlighter and editable placeholders scripts on the new tab content
+      Prism && Prism.highlightAll()
+      makePlaceholdersEditable && makePlaceholdersEditable()
     })
   })
 })()

--- a/src/partials/editable-placeholders-script.hbs
+++ b/src/partials/editable-placeholders-script.hbs
@@ -1,4 +1,9 @@
 <script>
+function makePlaceholdersEditable () {
+  createEditablePlaceholders();
+  addClasses()
+  addEvents()
+}
 function createEditablePlaceholders () {
   const codeElements = document.querySelectorAll("pre > code");
 
@@ -67,42 +72,40 @@ function addClasses () {
 
   editablePlaceholders.forEach((placeholder) => {
     placeholder.classList.add('editable');
-    placeholder.addEventListener('input', function(event) {
-      const dataType = event.target.dataset.type;
-      const newText = event.target.textContent;
-
-      document.querySelectorAll(`[data-type="${dataType}"][contenteditable="true"]`).forEach(span => {
-        if (span !== event.target) {
-          span.textContent = newText;
-        }
-      });
-    });
   });
 }
 
 function addEvents() {
   const editablePlaceholders = document.querySelectorAll('[contenteditable="true"], [contenteditable="true"] span');
-
   editablePlaceholders.forEach((placeholder) => {
     placeholder.addEventListener('input', function(event) {
       const dataType = event.target.dataset.type;
       const newText = event.target.textContent;
 
       document.querySelectorAll(`[data-type="${dataType}"][contenteditable="true"]`).forEach(span => {
-        if (span !== event.target) {
-          span.textContent = newText;
-          removeCursor(span)
+        // Check if the span is within a hidden tab
+        let hasHiddenAncestor = false
+        let ancestor = span.parentElement
+        while (ancestor) {
+            if (ancestor.classList.contains('tabpanel') && ancestor.classList.contains('is-hidden')) {
+                hasHiddenAncestor = true
+                break
+            }
+            ancestor = ancestor.parentElement
+        }
+        // Update the text if the span isn't within a hidden tab
+        if (!hasHiddenAncestor && span !== event.target) {
+            span.textContent = newText
+            removeCursor(span)
         }
       });
     });
-  });
+  })
 }
 
 window.onload = function() {
   try {
-    createEditablePlaceholders();
-    addClasses()
-    addEvents()
+    makePlaceholdersEditable()
   } catch (error) {
     console.error('An error occurred while making placeholders editable:', error);
   }


### PR DESCRIPTION
Updated our tabs to call `Prism.highlightAll()` when a new tab is clicked. Otherwise, the line highlighting is missing.