### PR TITLE
fix: highlights and editable placeholders in tabs

### DIFF
--- a/src/js/10-open-nested-tabs.js
+++ b/src/js/10-open-nested-tabs.js
@@ -13,15 +13,33 @@
   const tabs = document.querySelectorAll('li.tab')
   tabs.forEach(function (tab) {
     tab.addEventListener('click', function (event) {
-      const currentTab = event.target.parentElement
-      const id = currentTab.id
-      if (!id) return
+      const currentTab = event.target
+      let id = currentTab.id
+      if (!id) {
+        id = event.target.parentElement.id
+      }
+      const tabContent = document.getElementById(id + '--panel')
       const url = new URL(window.location.href)
       url.searchParams.set('tab', encodeURIComponent(id))
       window.history.pushState(null, null, url)
-      // Rerun the line highlighter and editable placeholders scripts on the new tab content
-      Prism && Prism.highlightAll()
-      makePlaceholdersEditable && makePlaceholdersEditable()
+      // Prism requires content to to visible
+      // so that it can calculate dimensions for the lines.
+      // Since tab content is hidden until clicked
+      // we need to rerun Prism when the tab is clicked
+      // so it can make the correct calculations.
+      // Prism also rewrites the content, so we lose editable placeholders.
+      // Rerun the script to make placeholders editable.
+      // TODO: Find a way to store editable placeholder state and reapply.
+      // If a user edits content in one tab and switches back and forth between another tab
+      // the content no longer matches the regex in editable placeholders
+      //so it is no longer editable
+      const preElementWithDataLine = tabContent.querySelector('.content pre[data-line]')
+      Promise.resolve().then(() => {
+        if (preElementWithDataLine) {
+          Prism && Prism.highlightAllUnder(tabContent)
+          makePlaceholdersEditable(tabContent)
+        }
+      })
     })
   })
 })()

--- a/src/partials/editable-placeholders-script.hbs
+++ b/src/partials/editable-placeholders-script.hbs
@@ -1,11 +1,13 @@
 <script>
-function makePlaceholdersEditable () {
-  createEditablePlaceholders();
-  addClasses()
-  addEvents()
+function makePlaceholdersEditable(element) {
+  createEditablePlaceholders(element);
+  addClasses(element)
+  addEvents(element)
 }
-function createEditablePlaceholders () {
-  const codeElements = document.querySelectorAll("pre > code");
+
+function createEditablePlaceholders(parentElement) {
+  const baseElement = parentElement || document;
+  const codeElements = baseElement.querySelectorAll("pre > code");
 
   for (let i = 0; i < codeElements.length; i++) {
     const codeElement = codeElements[i];
@@ -67,16 +69,18 @@ function removeCursor (element) {
   }
 }
 
-function addClasses () {
-  const editablePlaceholders = document.querySelectorAll('[contenteditable="true"], [contenteditable="true"] span');
+function addClasses(parentElement) {
+  const baseElement = parentElement || document;
+  const editablePlaceholders = baseElement.querySelectorAll('[contenteditable="true"], [contenteditable="true"] span');
 
   editablePlaceholders.forEach((placeholder) => {
     placeholder.classList.add('editable');
   });
 }
 
-function addEvents() {
-  const editablePlaceholders = document.querySelectorAll('[contenteditable="true"], [contenteditable="true"] span');
+function addEvents(parentElement) {
+  const baseElement = parentElement || document;
+  const editablePlaceholders = baseElement.querySelectorAll('[contenteditable="true"], [contenteditable="true"] span');
   editablePlaceholders.forEach((placeholder) => {
     placeholder.addEventListener('input', function(event) {
       const dataType = event.target.dataset.type;


### PR DESCRIPTION
 Prism requires content to to visible so that it can calculate dimensions for the lines. Since tab content is hidden until clicked, we need to rerun Prism when the tab is clicked so it can make the correct calculations. Prism also rewrites the content, so we lose editable placeholders.

- Adjusted editable placeholders script to take an element so that we can rerun it on tab content after it has been highlighted.
- Adjusted tab click event to run only on tab content that has the data-line attribute.