### PR TITLE
fix: reorder scripts and set timeout

### DIFF
--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -1,10 +1,10 @@
 <script defer src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
 <script defer src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
-<script defer id="site-script" src="{{{uiRootPath}}}/js/site.js" data-ui-root-path="{{{uiRootPath}}}"></script>
-<!--<script async src="{{{uiRootPath}}}/js/vendor/highlight.js"></script>-->
-<script async src="{{{uiRootPath}}}/js/vendor/tabs.js" data-sync-storage-key="preferred-tab"></script>
 <script defer src="{{{uiRootPath}}}/js/vendor/prism-line-numbers-plugin.js"></script>
 <script defer src="{{{uiRootPath}}}/js/vendor/prism-line-highlight-plugin.js"></script>
+<script async src="{{{uiRootPath}}}/js/vendor/tabs.js" data-sync-storage-key="preferred-tab"></script>
+<script defer id="site-script" src="{{{uiRootPath}}}/js/site.js" data-ui-root-path="{{{uiRootPath}}}"></script>
+<!--<script async src="{{{uiRootPath}}}/js/vendor/highlight.js"></script>-->
 {{#if (and env.ALGOLIA_API_KEY (ne page.layout 'search'))}}
 {{> algolia-script}}
 {{/if}}


### PR DESCRIPTION
- Reordered script execution so that dependencies are run first.
- Added `setTimeout` to tab click logic so that it runs after the tabs extension logic sets the display to block.


In the context of event handlers, suppose two event handlers A and B are attached to the same event on the same element. If A runs before B and if within A we have setTimeout(fn, 0), fn will run after A finishes but before B starts.