### PR TITLE
fix: remove query suggestions

### DIFF
--- a/src/partials/algolia-script.hbs
+++ b/src/partials/algolia-script.hbs
@@ -2,10 +2,6 @@
 window.addEventListener('DOMContentLoaded', function() {
   const { autocomplete, getAlgoliaResults } = window['@algolia/autocomplete-js'];
 
-  const { createQuerySuggestionsPlugin } = window[
-    '@algolia/autocomplete-plugin-query-suggestions'
-  ];
-
   const searchClient = algoliasearch(
     '{{{env.ALGOLIA_APP_ID}}}',
     '{{{env.ALGOLIA_API_KEY}}}'
@@ -211,6 +207,7 @@ window.addEventListener('DOMContentLoaded', function() {
             setContext({ preview: item });
           },
         },
+        /*
         {
           sourceId: 'suggestions',
           getItems({ query }) {
@@ -251,7 +248,7 @@ window.addEventListener('DOMContentLoaded', function() {
                 </div>`
             },
           },
-        }
+        }*/
       ];
     },
   });


### PR DESCRIPTION
Our new Algolia application doesn't support query suggestions. This PR removes the query suggestions index from the search client.