### PR TITLE
fix: reapply highlights in all synced tabs

### DIFF
--- a/src/js/10-open-nested-tabs.js
+++ b/src/js/10-open-nested-tabs.js
@@ -1,7 +1,7 @@
 /* global Prism */
 /* global makePlaceholdersEditable */
 
-;(function () {
+(function () {
   'use strict'
   window.addEventListener('DOMContentLoaded', function (event) {
     const url = new URL(window.location.href)
@@ -17,33 +17,45 @@
         if (!id) {
           id = event.target.parentElement.id
         }
-        setTimeout(() => {
-          const tabContent = document.getElementById(id + '--panel')
-          const url = new URL(window.location.href)
-          url.searchParams.set('tab', encodeURIComponent(id))
-          window.history.pushState(null, null, url)
-          // Prism requires content to be visible
-          // so that it can calculate dimensions for the lines.
-          // Since tab content is hidden until clicked
-          // we need to rerun Prism when the tab is clicked
-          // so it can make the correct calculations.
-          // Prism also rewrites the content, so we lose editable placeholders.
-          // Rerun the script to make placeholders editable.
-          // TODO: Find a way to store editable placeholder state and reapply.
-          // If a user edits content in one tab and switches back and forth between another tab
-          // the content no longer matches the regex in editable placeholders
-          //so it is no longer editable
-          const preElementWithDataLine = tabContent.querySelector('.content pre[data-line]')
-          preElementWithDataLine && waitForVisibility(preElementWithDataLine, () => {
-            if (Prism) {
-              Prism.highlightAllUnder(tabContent)
-              makePlaceholdersEditable(tabContent)
-            }
-          })
-        }, 0)
+        const url = new URL(window.location.href)
+        url.searchParams.set('tab', encodeURIComponent(id))
+        window.history.pushState(null, null, url)
+        // remove the 'tabs-' prefix and any number
+        const baseTabValue = id.replace(/tabs-\d+/i, '')
+        // Get all related (synced) tabs
+        const relatedTabs = document.querySelectorAll(`li.tab[id$="${baseTabValue}"]`)
+        relatedTabs.forEach((relatedTab) => {
+          const relatedTabId = relatedTab.id
+          setTimeout(() => {
+            handleTabSelection(relatedTabId)
+          }, 0)
+        })
       }, true)
     })
   })
+
+  // Prism requires content to be visible
+  // so that it can calculate dimensions for the lines.
+  // Since tab content is hidden until clicked
+  // we need to rerun Prism when the tab is clicked
+  // so it can make the correct calculations.
+  // Prism also rewrites the content, so we lose editable placeholders.
+  // Rerun the script to make placeholders editable.
+  // TODO: Find a way to store editable placeholder state and reapply.
+  // If a user edits content in one tab and switches back and forth between another tab
+  // the content no longer matches the regex in editable placeholders
+  //so it is no longer editable
+  function handleTabSelection (tabId) {
+    const tabContent = document.getElementById(tabId + '--panel')
+    const preElementWithDataLine = tabContent.querySelector('.content pre[data-line]')
+    preElementWithDataLine && waitForVisibility(preElementWithDataLine, () => {
+      if (Prism) {
+        Prism.highlightAllUnder(tabContent)
+        makePlaceholdersEditable(tabContent)
+      }
+    })
+  }
+
   function waitForVisibility (element, callback) {
     if (window.getComputedStyle(element, null).display !== 'none') {
       callback()


### PR DESCRIPTION
Adjusted the event handler to reapply code highlighting to all synced tabs.

Previously we were applying it only to the clicked tab, but synced tabs are opened at once so we need to apply the same logic to all synced tabs.