### PR TITLE
fix: broken selector

### DIFF
--- a/src/css/announcement-email.css
+++ b/src/css/announcement-email.css
@@ -85,7 +85,7 @@
   outline: none;
 }
 
-.announcement-email .hidden-announcement-email-footer {
+.announcement-email.hidden-announcement-email-footer {
   opacity: 0;
   pointer-events: none; /* This ensures the user can't interact with the faded-out footer */
 }


### PR DESCRIPTION
The `pointer-events:none` was never applied because the selector was incorrect, causing the announcement-email banner to prevent clicking certain elements at the bottom of the screen.