### PR TITLE
fix: Remove the margin on the version banner

### DIFF
--- a/src/css/banners.css
+++ b/src/css/banners.css
@@ -5,4 +5,6 @@
   border-radius: var(--admonition-border-radius);
   box-shadow: var(--admonition-border-box-shadow);
   padding: var(--admonition-padding);
+  margin-top: 0;
+  margin-bottom: 10px;
 }


### PR DESCRIPTION
Before:
![2023-10-04_18-53-57](https://github.com/redpanda-data/docs-ui/assets/45230295/59fd7d42-66c2-4ff0-a49a-5d4b13807815)


After:
![2023-10-04_18-53-14](https://github.com/redpanda-data/docs-ui/assets/45230295/95443a06-a83e-4f15-8ac2-a110bb86d490)
