### PR TITLE
feat: add support for two column lists

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -267,6 +267,10 @@
   margin: 1rem 0 0;
 }
 
+.doc .ulist.two-column {
+  column-count: 2;
+}
+
 .doc table.tableblock {
   font-size: calc(18 / var(--rem-base) * 1rem);
 }


### PR DESCRIPTION
Allow writers to define unordered lists that should span two columns to help with scanability:

```asciidoc
- General purpose: General-purpose instances provide a balance of compute, memory, and networking resources, and they can be used for a variety of diverse workloads.
+
[.two-column]
** https://aws.amazon.com/ec2/instance-types/m5/[M5d^]
** https://aws.amazon.com/ec2/instance-types/m5/[M5ad^]
** https://aws.amazon.com/ec2/instance-types/m5/[M5dn^]
** https://aws.amazon.com/ec2/instance-types/m6g/[M6gd^]
** https://aws.amazon.com/ec2/instance-types/m7g/[M7gd^]
```

![2023-10-10_11-21-59](https://github.com/redpanda-data/docs-ui/assets/45230295/b94466cc-cd1c-4b09-b538-9cbc793c734d)
