### PR TITLE
fix: Fix broken scroll in Redocly

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -11,6 +11,10 @@ html {
   scroll-behavior: smooth;
 }
 
+html.no-smooth-scroll {
+  scroll-behavior: unset;
+}
+
 @media screen and (min-width: 1024px) {
   html {
     font-size: var(--body-font-size--desktop);

--- a/src/js/03-fragment-jumper.js
+++ b/src/js/03-fragment-jumper.js
@@ -4,6 +4,8 @@
   var article = document.querySelector('article.doc')
   var toolbar = document.querySelector('.toolbar')
 
+  if (!article || !toolbar) return
+
   function decodeFragment (hash) {
     return hash && (~hash.indexOf('%') ? decodeURIComponent(hash) : hash).slice(1)
   }

--- a/src/layouts/swagger.hbs
+++ b/src/layouts/swagger.hbs
@@ -1,15 +1,28 @@
 <!DOCTYPE html>
-<html lang="en">
+<html class="no-smooth-scroll" lang="en">
   <head>
     {{> head defaultPageTitle='API Reference'}}
     <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
-    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>
   </head>
   <body class="swagger">
     {{> header}}
+    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"> </script>
     <div id="redoc-container"></div>
     <script>
+    // Calculate offset for scroll.
+    // See https://redocly.com/docs/redoc/config/#scrollyoffset
+    function getNavbarHeight() {
+      const navbar = document.querySelector('nav.navbar');
+      if (!navbar) {
+          console.error('Navbar not found.');
+          return null;
+      }
+      const style = window.getComputedStyle(navbar);
+      const height = parseFloat(style.height);
+      return height;
+    }
     Redoc.init('{{resolve-resource page.attributes.api-spec-url}}', {
+      scrollYOffset: getNavbarHeight
     }, document.getElementById('redoc-container'))
     </script>
     {{> footer}}


### PR DESCRIPTION
Fixes redpanda-data/documentation-private#2008

Scrolling was broken due to a bug in Redocly. See https://github.com/Redocly/redoc/issues/1235

This PR implements a published workaround by removing `scroll-behavior: smooth;` from the `html` element in the API docs template.