### PR TITLE
Add styles to tooltips

### DIFF
--- a/src/css/site.css
+++ b/src/css/site.css
@@ -37,3 +37,4 @@
 @import "announcement-banner.css";
 @import "announcement-email.css";
 @import "prism.css";
+@import "tooltips.css";

--- a/src/css/tooltips.css
+++ b/src/css/tooltips.css
@@ -1,0 +1,8 @@
+.tippy-box[data-theme~='redpanda-term'] {
+  font-size: 0.9em;
+}
+
+a.glossary-term {
+  border-bottom: 2px dotted var(--link-font-color);
+  text-decoration: none !important;
+}

--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -16,6 +16,9 @@
 <script>
 tippy('[data-tippy-content]', {
   animation: 'scale',
-  theme: 'redpanda-term'
+  theme: 'redpanda-term',
+  touch: 'hold',
+  interactive: true,
+  allowHTML: true
 });
 </script>


### PR DESCRIPTION
Styled tooltips so that users know the difference between a normal link and one that has a tooltip attached. Also made the hover text slightly larger for readability.

![2023-11-21_11-14-53](https://github.com/redpanda-data/docs-ui/assets/45230295/abd801fe-979e-405e-ba03-5ca8e4d11568)
