### PR TITLE
Handle large tables

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -272,7 +272,7 @@
 }
 
 .doc table.tableblock {
-  font-size: calc(18 / var(--rem-base) * 1rem);
+  font-size: calc(19 / var(--rem-base) * 1rem);
 }
 
 .doc .tablecontainer,
@@ -280,6 +280,33 @@
 .doc :not(.tablecontainer) > table.tableblock,
 .doc :not(.tablecontainer) > table.tableblock + * {
   margin-top: 1.5rem;
+}
+
+.doc .tablecontainer {
+  max-height: 350px;
+  overflow-y: auto;
+}
+
+.doc .tablecontainer::-webkit-scrollbar {
+  width: 10px;
+}
+
+.doc .tablecontainer::-webkit-scrollbar-track {
+  background: #f1f1f1;
+}
+
+.doc .tablecontainer::-webkit-scrollbar-thumb {
+  background-color: #888;
+  border-radius: 5px;
+  min-height: 50px;
+  border: 3px solid #f1f1f1;
+}
+
+.doc .tablecontainer table.tableblock thead {
+  background: #f6f6f6;
+  position: sticky;
+  top: -1px;
+  z-index: var(--z-index-nav);
 }
 
 .doc p.tableblock + p.tableblock {

--- a/src/js/14-find-large-tables.js
+++ b/src/js/14-find-large-tables.js
@@ -1,0 +1,14 @@
+(function () {
+  'use strict'
+  document.addEventListener('DOMContentLoaded', function () {
+    const tables = document.querySelectorAll('table.tableblock')
+    tables && tables.forEach((table) => {
+      if (table.offsetHeight > 350) {
+        const wrapper = document.createElement('div')
+        wrapper.className = 'tablecontainer'
+        table.parentNode.insertBefore(wrapper, table)
+        wrapper.appendChild(table)
+      }
+    })
+  })
+})()


### PR DESCRIPTION
Finds tables that are higher than 350px and wraps them in a container that scrolls so that they don't stop users from scanning content.