### PR TITLE
Add filterable search

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -148,8 +148,8 @@
   color: var(--link_unresolved-font-color);
 }
 
-.doc a[href*="//"]:not([href*="docs.redpanda.com"]):not(section.feedback-section a)::after,
-.doc a[href*="//"]:not([href*="netlify.app"]):not(section.feedback-section a)::after {
+.doc a[href*="//"]:not([href*="docs.redpanda.com"]):not(section.feedback-section a):not(.aa-ItemIcon a)::after,
+.doc a[href*="//"]:not([href*="netlify.app"]):not(section.feedback-section a):not(.aa-ItemIcon a)::after {
   content: url('/_/img/external-link.svg');
   position: relative;
   margin-left: 2px;

--- a/src/css/nav.css
+++ b/src/css/nav.css
@@ -21,6 +21,57 @@
   width: 100%;
 }
 
+.top-panel .search {
+  padding: 5px;
+  border-bottom: 1px solid var(--toolbar-border-color);
+}
+
+.top-panel .dropdown .dropdown-content {
+  display: none;
+  flex-direction: column;
+  font-size: 1.1em;
+}
+
+.top-panel .dropdown .dropdown-content.is-active {
+  display: flex;
+  padding: 5px;
+}
+
+.top-panel .dropdown .search-filters {
+  padding: 5px;
+  cursor: pointer;
+  font-size: 1.2em;
+  display: flex;
+  gap: 10px;
+  color: var(--nav-muted-color);
+}
+
+.top-panel .dropdown .search-filters .filter-toggle {
+  display: flex;
+  align-items: center;
+}
+
+.top-panel .dropdown .search-filters .filter-toggle::after {
+  content: "";
+  background: url(../img/chevron.svg) no-repeat 100%/auto 100%;
+  width: 1.1em;
+  height: 0.75em;
+}
+
+.top-panel .dropdown .search-filters .selected-items {
+  font-size: 0.9em;
+  gap: 2px;
+  flex-wrap: wrap;
+  display: flex;
+}
+
+.top-panel .dropdown .search-filters .selected-items span {
+  background-color: var(--page-version-menu-background);
+  border-radius: 5px;
+  color: var(--page-version-font-color);
+  padding: 2px 3px;
+}
+
 @media screen and (min-width: 769px) {
   .nav-container {
     width: var(--nav-width);

--- a/src/css/search.css
+++ b/src/css/search.css
@@ -252,8 +252,20 @@ kbd.algolia-command {
   text-decoration: none;
 }
 
+.aa-Preview.aa-Column.doc {
+  margin-top: 0;
+}
+
 .aa-ItemIcon {
   margin: 10px auto;
+  height: unset !important;
+  width: unset !important;
+}
+
+.aa-ItemIcon img {
+  max-width: 100% !important;
+  height: auto !important;
+  max-height: unset !important;
 }
 
 .aa-Results.aa-Column {

--- a/src/css/search.css
+++ b/src/css/search.css
@@ -256,6 +256,10 @@ kbd.algolia-command {
   margin-top: 0;
 }
 
+.aa-ItemContentTitle.result-type {
+  font-size: smaller;
+}
+
 .aa-ItemIcon {
   margin: 10px auto;
   height: unset !important;

--- a/src/css/toolbar.css
+++ b/src/css/toolbar.css
@@ -11,10 +11,6 @@
   z-index: var(--z-index-toolbar);
 }
 
-html:not([data-theme=dark]) .toolbar {
-  box-shadow: 0 1px 0 var(--toolbar-border-color);
-}
-
 .toolbar a {
   color: inherit;
 }

--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -70,12 +70,11 @@
     const dropdownContainers = explorePanel.querySelectorAll('.context .container.has-dropdown')
 
     dropdownContainers.forEach((container) => {
-      container.addEventListener('mouseover', () => {
-        container.classList.add('is-active')
+      container.addEventListener('click', () => {
+        container.classList.toggle('is-active')
       })
     })
-
-    explorePanel.addEventListener('mouseleave', () => {
+    document.documentElement.addEventListener('click', function () {
       dropdownContainers.forEach((container) => {
         container.classList.remove('is-active')
       })

--- a/src/js/14-find-large-tables.js
+++ b/src/js/14-find-large-tables.js
@@ -3,7 +3,7 @@
   document.addEventListener('DOMContentLoaded', function () {
     const tables = document.querySelectorAll('table.tableblock')
     tables && tables.forEach((table) => {
-      if (table.offsetHeight > 350) {
+      if (table.offsetHeight > 700) {
         const wrapper = document.createElement('div')
         wrapper.className = 'tablecontainer'
         table.parentNode.insertBefore(wrapper, table)

--- a/src/layouts/search.hbs
+++ b/src/layouts/search.hbs
@@ -71,6 +71,7 @@ if (typeof algoliasearch != "undefined" && typeof instantsearch != "undefined") 
 
           return `
             <div>
+                <p class="ais-Breadcrumbs">${hit.type}</p>
                 <p class="ais-Heading"><a href="${hit.objectID}">${hit.title}</a></p>
                 <p class="ais-Breadcrumbs">${breadcrumbsHtml}</p>
             </div>`;

--- a/src/partials/algolia-script.hbs
+++ b/src/partials/algolia-script.hbs
@@ -1,6 +1,6 @@
 <script>
 
-let filters = [['{{#if (or (eq page.component.title home)(eq page.component.layout 404))}}{{{site.components.ROOT.latest.title}}}-{{{site.components.ROOT.latest.version}}}{{else}}{{{page.component.title}}}-{{{page.componentVersion.version}}}{{/if}}']];
+let filters = [['{{#if (or (eq page.component.title home)(eq page.component.layout 404))}}{{{site.components.ROOT.latest.title}}}-{{{site.components.ROOT.latest.version}}}{{else}}{{{page.component.title}}}-{{{page.componentVersion.version}}}{{/if}}', 'apis']];
 
 function getCheckboxFilters(filters) {
   const checkboxes = document.querySelectorAll('.filter-checkbox');
@@ -17,11 +17,51 @@ function getCheckboxFilters(filters) {
       }
     }
   });
+  window.localStorage.setItem('appliedSearchFilters', JSON.stringify(filters[0]));
   return filters;
 }
 
+function loadFilters() {
+  const savedFilters = JSON.parse(localStorage.getItem('appliedSearchFilters'));
+  if (savedFilters && savedFilters.length > 0) {
+    const checkboxes = document.querySelectorAll('.filter-checkbox');
+    checkboxes.forEach(checkbox => {
+      const filterName = checkbox.getAttribute('data-filter-name');
+      checkbox.checked = savedFilters.includes(filterName);
+      updateSelection(checkbox);
+    });
+  }
+}
+
+function toggleDropdown() {
+  var isOpen = document.getElementById("search-filters").classList.toggle("is-active");
+  var dropdown = document.getElementById("filters-dropdown");
+  dropdown.setAttribute("aria-expanded", isOpen);
+}
+
+window.onclick = function(event) {
+  if (!event.target.matches('.dropdown button')) {
+    var dropdowns = document.getElementsByClassName("dropdown-content");
+    for (var i = 0; i < dropdowns.length; i++) {
+      var openDropdown = dropdowns[i];
+      if (openDropdown.classList.contains('is-active')) {
+        openDropdown.classList.remove('is-active');
+      }
+    }
+  }
+}
+
+function updateSelection(checkbox) {
+  var selectedItemsDiv = document.getElementById("selectedItems");
+  if (checkbox.checked) {
+    selectedItemsDiv.innerHTML += "<span>" + checkbox.getAttribute('data-filter-name') + " </span>";
+  } else {
+    selectedItemsDiv.innerHTML = selectedItemsDiv.innerHTML.replace("<span>" + checkbox.getAttribute('data-filter-name') + " </span>", "");
+  }
+}
 
 window.addEventListener('DOMContentLoaded', function() {
+  loadFilters();
   const { autocomplete, getAlgoliaResults } = window['@algolia/autocomplete-js'];
 
   const searchClient = algoliasearch(
@@ -97,9 +137,19 @@ window.addEventListener('DOMContentLoaded', function() {
               ${
                 preview.image
                 ? html`<div class="aa-ItemIcon">
-                        <img
+                        <a
+                        onclick="${(event) => {
+                        event.stopPropagation();
+                        aa('clickedObjectIDsAfterSearch',{
+                          eventName: 'Preview Selected',
+                          index: state.context.preview.__autocomplete_indexName,
+                          queryID: state.context.preview.__autocomplete_queryID,
+                          objectIDs: [state.context.preview.objectID],
+                          positions: [state.activeItemId + 1] // positions start from 1 but itemIds start from 0
+                        })
+                      }}" href="${preview.objectID}"><img
                           src="${preview.image}"
-                        />
+                        /></a>
                       </div>`
                 : ''
               }
@@ -163,12 +213,19 @@ window.addEventListener('DOMContentLoaded', function() {
             noResults({state, html}) {
               state.context.preview = null
               if (!state.query) return
-              return html`<div>No results for ${state.query}</div><p>Believe this query should return results?<a target="_blank" href="https://github.com/redpanda-data/documentation/issues/new?title=No%20search%20results%20for%20${state.query}"> Let us know</a>.</p>`;
+              return html`
+              <div>No results for ${state.query}</div><p>Believe this query should return results?<a target="_blank" href="https://github.com/redpanda-data/documentation/issues/new?title=No%20search%20results%20for%20${state.query}"> Let us know</a>.</p>`;
             },
-            header({html}) {
-              return html`<span class="aa-SourceHeaderTitle">{{#if (or (eq page.component.title 'home') (eq page.component.layout '404'))}}Redpanda{{else}}{{{page.component.title}}}{{/if}} {{#if (or (eq page.component.title 'home')(eq page.component.layout '404'))}}{{{site.components.ROOT.latest.version}}}{{else}}{{{page.version}}}{{/if}} Docs</span>
-              <div class="aa-SourceHeaderLine"></div>
-              `;
+            header({items, html}) {
+              if (!items.length) {
+                return;
+              }
+              let headerTitle = "{{#if (or (eq page.component.title 'home') (eq page.component.layout '404'))}}Redpanda{{else}}{{{page.component.title}}}{{/if}} {{#if (or (eq page.component.title 'home')(eq page.component.layout '404'))}}{{{site.components.ROOT.latest.version}}}{{else}}{{{page.version}}}{{/if}}";
+
+
+              return html`
+              <span class="aa-SourceHeaderTitle">${headerTitle}</span>
+              <div class="aa-SourceHeaderLine"></div>`;
             },
             footer({state, html}) {
               if (state.context.preview) {
@@ -181,6 +238,11 @@ window.addEventListener('DOMContentLoaded', function() {
               return html`<a class="aa-ItemLink" href="${item.objectID}">
                 <div class="aa-ItemContent">
                   <div class="aa-ItemContentBody">
+                    <div class="aa-ItemContentRow">
+                      <div class="aa-ItemContentTitle result-type">
+                        ${item.type}
+                      </div>
+                    </div>
                     <div class="aa-ItemContentRow">
                       <div class="aa-ItemContentTitle">
                         ${components.Highlight({

--- a/src/partials/algolia-script.hbs
+++ b/src/partials/algolia-script.hbs
@@ -1,4 +1,26 @@
 <script>
+
+let filters = [['{{#if (or (eq page.component.title home)(eq page.component.layout 404))}}{{{site.components.ROOT.latest.title}}}-{{{site.components.ROOT.latest.version}}}{{else}}{{{page.component.title}}}-{{{page.componentVersion.version}}}{{/if}}']];
+
+function getCheckboxFilters(filters) {
+  const checkboxes = document.querySelectorAll('.filter-checkbox');
+  checkboxes.forEach(checkbox => {
+    const filterName = checkbox.getAttribute('data-filter-name');
+    const isFilterInArray = filters[0].includes(filterName);
+    if (checkbox.checked) {
+      if (!isFilterInArray) {
+        filters[0].push(filterName);
+      }
+    } else {
+      if (isFilterInArray) {
+        filters[0] = filters[0].filter(item => item !== filterName);
+      }
+    }
+  });
+  return filters;
+}
+
+
 window.addEventListener('DOMContentLoaded', function() {
   const { autocomplete, getAlgoliaResults } = window['@algolia/autocomplete-js'];
 
@@ -41,18 +63,6 @@ window.addEventListener('DOMContentLoaded', function() {
           ? html`<div class="aa-Preview aa-Column doc">
             <div class="aa-PanelLayout aa-Panel--scrollable">
               ${
-                preview.image
-                ? html`<div class="aa-ItemIcon">
-                        <img
-                          src="${preview.image.src}"
-                          alt="${preview.image.alt}"
-                          width="40"
-                          height="40"
-                        />
-                      </div>`
-                : ''
-              }
-              ${
                 preview.breadcrumbs
                 ? html`<div class="breadcrumbs">
                 <ul>
@@ -84,13 +94,22 @@ window.addEventListener('DOMContentLoaded', function() {
                   attribute: 'intro',
                 })}
               </p>
+              ${
+                preview.image
+                ? html`<div class="aa-ItemIcon">
+                        <img
+                          src="${preview.image}"
+                        />
+                      </div>`
+                : ''
+              }
               <div class="toc sidebar">
                 <div class="toc-menu">
-                  ${preview.titles.length > 0 ?
+                  ${preview.titles && preview.titles.length > 0 ?
                   html`<h4>On this page</h4>`
                   : ''}
                   <ul>
-                  ${preview.titles.map(title =>
+                  ${preview.titles && preview.titles.length > 0 && preview.titles.map(title =>
                     html`<li><a onclick="${(event) => {
                     event.stopPropagation();
                     aa('clickedObjectIDsAfterSearch',{
@@ -118,6 +137,7 @@ window.addEventListener('DOMContentLoaded', function() {
       );
     },
     getSources({ query }) {
+      const appliedFilters = getCheckboxFilters(filters);
       return [
         {
           sourceId: 'docs',
@@ -133,7 +153,7 @@ window.addEventListener('DOMContentLoaded', function() {
                     hitsPerPage: 10,
                     attributesToSnippet: ['title:7'],
                     snippetEllipsisText: '…',
-                    facetFilters: ['version: {{#if (or (eq page.component.title 'home')(eq page.component.layout '404'))}}{{{site.components.ROOT.latest.version}}}{{else}}{{{page.version}}}{{/if}}','product: {{#if (or (eq page.component.title 'home') (eq page.component.layout '404'))}}Redpanda{{else}}{{{page.component.title}}}{{/if}}']
+                    tagFilters: appliedFilters,
                   },
                 },
               ],
@@ -146,7 +166,7 @@ window.addEventListener('DOMContentLoaded', function() {
               return html`<div>No results for ${state.query}</div><p>Believe this query should return results?<a target="_blank" href="https://github.com/redpanda-data/documentation/issues/new?title=No%20search%20results%20for%20${state.query}"> Let us know</a>.</p>`;
             },
             header({html}) {
-              return html`<span class="aa-SourceHeaderTitle">{{#if (or (eq page.component.title 'home') (eq page.component.layout '404'))}}Redpanda{{else}}{{{page.component.title}}}{{/if}} {{#if (or (eq page.component.title 'home')(eq page.component.layout '404'))}}{{{site.components.ROOT.latest.version}}}{{else}}{{{page.version}}}{{/if}}</span>
+              return html`<span class="aa-SourceHeaderTitle">{{#if (or (eq page.component.title 'home') (eq page.component.layout '404'))}}Redpanda{{else}}{{{page.component.title}}}{{/if}} {{#if (or (eq page.component.title 'home')(eq page.component.layout '404'))}}{{{site.components.ROOT.latest.version}}}{{else}}{{{page.version}}}{{/if}} Docs</span>
               <div class="aa-SourceHeaderLine"></div>
               `;
             },

--- a/src/partials/nav.hbs
+++ b/src/partials/nav.hbs
@@ -6,7 +6,17 @@
     <div class="top-panel">
     {{#if (ne page.layout 'search')}}
       <div class="search hide-for-print">
-          <div id="autocomplete"></div>
+        <div id="autocomplete"></div>
+        <div class="filter-options">
+          <label>
+            <input type="checkbox" class="filter-checkbox" data-filter-name="blogs">
+            Include blog posts
+          </label>
+          <label>
+            <input type="checkbox" class="filter-checkbox" data-filter-name="videos">
+            Include YouTube videos
+          </label>
+        </div>
       </div>
     {{/if}}
     {{> nav-explore}}

--- a/src/partials/nav.hbs
+++ b/src/partials/nav.hbs
@@ -7,15 +7,18 @@
     {{#if (ne page.layout 'search')}}
       <div class="search hide-for-print">
         <div id="autocomplete"></div>
-        <div class="filter-options">
-          <label>
-            <input type="checkbox" class="filter-checkbox" data-filter-name="blogs">
-            Include blog posts
-          </label>
-          <label>
-            <input type="checkbox" class="filter-checkbox" data-filter-name="videos">
-            Include YouTube videos
-          </label>
+        <div class="dropdown">
+        <div class="search-filters" id="filters-dropdown" aria-haspopup="true" aria-expanded="false" onclick="toggleDropdown()"><div class="filter-toggle">Search filters</div><div class="selected-items" id="selectedItems"></div></div>
+          <div id="search-filters" class="dropdown-content">
+            <label>
+              <input type="checkbox" class="filter-checkbox" data-filter-name="blogs" onchange="updateSelection(this)">
+              Include blog posts
+            </label>
+            <label>
+              <input type="checkbox" class="filter-checkbox" data-filter-name="videos" onchange="updateSelection(this)">
+              Include YouTube videos
+            </label>
+          </div>
         </div>
       </div>
     {{/if}}


### PR DESCRIPTION
Allows users to include Redpanda blog posts and Redpanda YouTube videos in search results.

After enabling a filter and searching, the filter is stored in local storage for future searches.

Dynamically generates [`tagFilters`](https://www.algolia.com/doc/api-reference/api-parameters/tagFilters/) using a combination of the search filters in the UI and some static data such as redpanda doc versions.

Fixes https://github.com/redpanda-data/documentation-private/issues/2127

preview: https://deploy-preview-139--docs-ui.netlify.app/