### PR TITLE
Display docs for in-context version

### DIFF
--- a/src/partials/algolia-script.hbs
+++ b/src/partials/algolia-script.hbs
@@ -10,11 +10,14 @@ function mapToAlgoliaFilters(tagsByFacet) {
   Object.keys(tagsByFacet).forEach(facet => {
     tagsByFacet[facet].forEach(tag => {
       const filterString = tag.label;
-      const isFilterInArray = filters[0].includes(filterString);
-      if (!isFilterInArray) {
-        filters[0].push(filterString);
-      } else {
-        filters[0] = filters[0].filter(item => item !== filterString);
+      // Don't add the docs filter as it allows all versions to be displayed in results.
+      if (tag.label !== 'docs') {
+        const isFilterInArray = filters[0].includes(filterString);
+        if (!isFilterInArray) {
+          filters[0].push(filterString);
+        } else {
+          filters[0] = filters[0].filter(item => item !== filterString);
+        }
       }
     });
   });


### PR DESCRIPTION
This PR makes sure that we don't add the `type: docs` filter to the Algolia search options.

The filters use the OR operator. All versioned results have this 'docs' type so adding it returns all versions. We want to return only the version that's relevant to the current doc page version.