### PR TITLE
Allow users to filter by version in detached search mode

### DIFF
--- a/src/css/header.css
+++ b/src/css/header.css
@@ -211,7 +211,7 @@ body {
   }
 }
 
-@media screen and (max-width: 1023.5px) {
+@media screen and (max-width: 1040px) {
   .navbar-brand {
     height: inherit;
   }

--- a/src/css/header.css
+++ b/src/css/header.css
@@ -240,7 +240,7 @@ body {
   }
 }
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: 1040px) {
   .navbar-burger {
     display: none;
   }

--- a/src/css/search.css
+++ b/src/css/search.css
@@ -347,7 +347,6 @@ li.aa-Item:not([id*="filters"]) {
 }
 
 .aa-ItemActionButton svg {
-  color: white !important;
   height: 15px;
   width: unset;
   margin: 5px;
@@ -355,12 +354,19 @@ li.aa-Item:not([id*="filters"]) {
 
 .aa-Source[data-autocomplete-source-id="filters"] .aa-List {
   display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.aa-Source[data-autocomplete-source-id="filters"] .aa-ItemContentTitle {
+  font-size: 0.85em;
 }
 
 .aa-Source[data-autocomplete-source-id="filters"] .aa-List .aa-Item {
   min-height: unset;
   padding-top: 0;
   padding-bottom: 0;
+  border: 1px solid #dadde1;
 }
 
 .aa-Source[data-autocomplete-source-id=tagsPlugin] .aa-Item {
@@ -409,6 +415,10 @@ li.aa-Item:not([id*="filters"]) {
 .aa-Item[aria-selected=true] {
   background-color: var(--link-font-color) !important;
   color: white !important;
+}
+
+.aa-ActiveOnly {
+  visibility: visible !important;
 }
 
 .aa-ItemContentTitle {

--- a/src/layouts/swagger.hbs
+++ b/src/layouts/swagger.hbs
@@ -4,7 +4,6 @@
     {{> head defaultPageTitle='API Reference'}}
     <meta charset="utf-8">
     <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
-    {{> head-scripts}}
     {{> header-scripts}}
   </head>
   <body class="body swagger" style="padding-top:0; height:100vh;">

--- a/src/partials/algolia-script.hbs
+++ b/src/partials/algolia-script.hbs
@@ -1,27 +1,21 @@
 <script>
 
-const INITIAL_TAG = "{{#if (eq page.component.name 'redpanda-labs')}}labs{{else}}docs{{/if}}"
+const INITIAL_TAG = "{{#if (eq page.component.name 'redpanda-labs')}}labs{{else if (eq page.component.name 'api')}}{{{site.components.ROOT.title}}} v{{{site.components.ROOT.latest.version}}}{{else if page.componentVersion.version}}{{{page.component.title}}} v{{{page.componentVersion.version}}}{{else}}{{{page.component.title}}}{{/if}}"
 
 const VERSION = "{{#if (or (eq page.component.title home) (eq page.component.layout 404) (eq page.component.name 'redpanda-labs'))}}{{{site.components.ROOT.latest.version}}}{{else}}{{{page.componentVersion.version}}}{{/if}}"
 
 function mapToAlgoliaFilters(tagsByFacet) {
-  const hasDocsTag = Object.values(tagsByFacet).flat().some(tag => tag.label === 'docs');
 
-  let filters = hasDocsTag
-    ? [["{{#if (or (eq page.component.title home) (eq page.component.layout 404) (eq page.component.name 'redpanda-labs'))}}{{{site.components.ROOT.latest.title}}}-{{{site.components.ROOT.latest.version}}}{{else}}{{{page.component.title}}}-{{{page.componentVersion.version}}}{{/if}}", 'apis']]
-    : [[]];
+  let filters = [[]];
 
   Object.keys(tagsByFacet).forEach(facet => {
     tagsByFacet[facet].forEach(tag => {
       const filterString = tag.label;
-      // Don't add the docs filter as it allows all versions to be displayed in results.
-      if (tag.label !== 'docs') {
-        const isFilterInArray = filters[0].includes(filterString);
-        if (!isFilterInArray) {
-          filters[0].push(filterString);
-        } else {
-          filters[0] = filters[0].filter(item => item !== filterString);
-        }
+      const isFilterInArray = filters[0].includes(filterString);
+      if (!isFilterInArray) {
+        filters[0].push(filterString);
+      } else {
+        filters[0] = filters[0].filter(item => item !== filterString);
       }
     });
   });
@@ -281,7 +275,7 @@ window.addEventListener('DOMContentLoaded', function() {
               if (!items.length) {
                 return;
               }
-              let headerTitle = "Search In";
+              let headerTitle = "Narrow your search";
               return html`
               <span class="aa-SourceHeaderTitle">${headerTitle}</span>
               <div class="aa-SourceHeaderLine"></div>`;
@@ -357,15 +351,24 @@ window.addEventListener('DOMContentLoaded', function() {
             footer({state, html}) {
               if (state.context.preview) {
                 // Extract tags and format them for URL encoding as array parameters
-                const tag = state.context.tagsPlugin.tags[0]
-                // Convert to init caps and singular
-                const label = tag.label.charAt(0).toUpperCase() + tag.label.slice(1);
+                const tag = state.context.tagsPlugin.tags[0];
+                let label = 'docs'; // Default to 'docs'
+
+                // Check if a tag is selected and its first character is not uppercase
+                if (tag && !tag.label.charAt(0) !== tag.label.charAt(0).toUpperCase()) {
+                  label = tag.label; // Use the tag label if it doesn't start with an uppercase character
+                }
+
+                // Capitalize the first character of the label
+                label = label.charAt(0).toUpperCase() + label.slice(1);
+
+                // Convert label to singular if it ends with 's'
                 const formattedLabel = label.endsWith('s') ? label.slice(0, -1) : label;
+
                 // Encode as array parameter
                 const type = `type[0]=${encodeURIComponent(formattedLabel)}`;
                 const queryParam = state.query ? `&q=${encodeURIComponent(state.query)}` : '';
                 var queryParams = `${type}${queryParam}`;
-                console.log(label)
                 if (formattedLabel === 'Doc' && VERSION) {
                    queryParams += `&version=${VERSION}`
                 }
@@ -401,13 +404,21 @@ window.addEventListener('DOMContentLoaded', function() {
                       </div>
                     </div>`
                     : ''
-                  }
-                    <div class="aa-ItemContentSnippet">
+                    }
+                    ${ item.text
+                    ? html`<div class="aa-ItemContentSnippet">
                       ${components.Snippet({
                         hit: item,
                         attribute: 'text',
                       })}
-                    </div>
+                    </div>`
+                    : html`<div class="aa-ItemContentSnippet">
+                      ${components.Snippet({
+                        hit: item,
+                        attribute: 'intro',
+                      })}
+                    </div>`
+                    }
                     <div class="aa-ItemContentRow">
                       <div class="aa-ItemContentTitle result-type">
                         ${item.type}

--- a/src/partials/algolia-script.hbs
+++ b/src/partials/algolia-script.hbs
@@ -355,7 +355,7 @@ window.addEventListener('DOMContentLoaded', function() {
                 let label = 'docs'; // Default to 'docs'
 
                 // Check if a tag is selected and its first character is not uppercase
-                if (tag && !tag.label.charAt(0) !== tag.label.charAt(0).toUpperCase()) {
+                if (tag && tag.label.charAt(0) !== tag.label.charAt(0).toUpperCase()) {
                   label = tag.label; // Use the tag label if it doesn't start with an uppercase character
                 }
 

--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -2,3 +2,6 @@
 {{#if (or (is-prerelease page) site.keys.preview)}}
 <meta name="robots" content="noindex">
 {{/if}}
+{{#with site.components.ROOT}}
+<meta name="latest-redpanda-version" content="{{this.latest.version}}">
+{{/with}}


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/documentation-private/issues/2294

Preview: https://deploy-preview-394--redpanda-docs-preview.netlify.app/current/get-started/intro-to-events/

With this change, users can more clearly see which version of our product docs they are currently filtering by and select other versions.

![2024-04-04_11-34-19](https://github.com/redpanda-data/docs-ui/assets/45230295/4d747d59-6cfe-4e5a-bf6d-201fe2b712cf)

Related PRs:
- https://github.com/redpanda-data/docs-extensions-and-macros/pull/33
- https://github.com/redpanda-data/docs-site/pull/48