### PR TITLE
Enable side-by-side code snippets

### DIFF
--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -237,6 +237,46 @@ Here we just have some plain text.
 plain text
 ----
 
+==== Side-by-side code
+
+[.side-by-side]
+--
+.Strimzi
+[source,yaml]
+----
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: my-topic <1>
+  labels:
+    strimzi.io/cluster: my-kafka-cluster <2>
+spec:
+  partitions: 3 <3>
+  replicas: 3 <4>
+----
+
+.Redpanda
+[source,yaml]
+----
+apiVersion: cluster.redpanda.com/v1alpha1
+kind: Topic
+metadata:
+  name: my-topic <1>
+spec:
+  kafkaApiSpec: <2>
+    brokers:
+      - "redpanda-0.redpanda.<namespace>.svc.cluster.local:9093"
+      - "redpanda-1.redpanda.<namespace>.svc.cluster.local:9093"
+      - "redpanda-2.redpanda.<namespace>.svc.cluster.local:9093"
+    tls:
+      caCertSecretRef:
+        name: "redpanda-default-cert"
+        key: "ca.crt"
+  partitions: 3 <3>
+  replicationFactor: 3 <4>
+----
+--
+
 [.rolename]
 === Liber recusabo
 

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -47,6 +47,19 @@
   margin-top: 0;
 }
 
+@media screen and (min-width: 600px) {
+  .doc .openblock.side-by-side > .content {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .doc .openblock.side-by-side > .content > * {
+    flex: 1;
+    padding: 10px;
+    width: 0;
+  }
+}
+
 @media screen and (min-width: 769px) {
   .doc h1 {
     font-size: calc(48 / var(--rem-base) * 1rem);
@@ -798,15 +811,6 @@ table code {
   margin-bottom: -0.75rem;
   padding: 1rem;
   background-color: var(--caption-background-color);
-}
-
-.doc .openblock.side-by-side > .content {
-  display: flex;
-}
-
-.doc .openblock.side-by-side > .content > * {
-  flex: 1;
-  padding: 10px;
 }
 
 /* immediate sibling of an element with the class title, where this title class element is a direct child of a td element with the class content */

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -800,6 +800,15 @@ table code {
   background-color: var(--caption-background-color);
 }
 
+.doc .openblock.side-by-side > .content {
+  display: flex;
+}
+
+.doc .openblock.side-by-side > .content > * {
+  flex: 1;
+  padding: 10px;
+}
+
 /* immediate sibling of an element with the class title, where this title class element is a direct child of a td element with the class content */
 .doc .admonitionblock td.content > .title + * {
   margin-top: 20px;

--- a/src/js/14-find-large-tables-and-code-blocks.js
+++ b/src/js/14-find-large-tables-and-code-blocks.js
@@ -17,7 +17,6 @@
         element.parentNode.insertBefore(wrapper, element)
         wrapper.appendChild(element)
         wrapper.style.overflow = 'scroll'
-        wrapper.style.maxHeight = '400px'
         wrapper.style.transition = 'max-height 0.5s ease'
 
         // Create a new container for the button with flex styling
@@ -27,9 +26,9 @@
         buttonContainer.style.marginTop = '-10px'
 
         const readMoreBtn = document.createElement('button')
-        readMoreBtn.innerText = contentType === 'table' ? 'Show full table' : 'View more code'
+        readMoreBtn.innerText = contentType === 'table' ? 'Reduce table height' : 'Reduce code height'
         readMoreBtn.className = 'badge-button'
-        readMoreBtn.setAttribute('aria-expanded', 'false')
+        readMoreBtn.setAttribute('aria-expanded', 'true')
         readMoreBtn.setAttribute('role', 'button')
         readMoreBtn.setAttribute('tabindex', '0')
 
@@ -43,8 +42,8 @@
         const storedState = window.localStorage.getItem(key)
         if (storedState === 'true') {
           wrapper.style.maxHeight = `${element.scrollHeight}px`
-          readMoreBtn.innerText = contentType === 'table' ? 'Hide full table' : 'View less code'
-          readMoreBtn.setAttribute('aria-expanded', 'true')
+          readMoreBtn.innerText = contentType === 'table' ? 'Expand table' : 'Expand code block'
+          readMoreBtn.setAttribute('aria-expanded', 'false')
         }
 
         readMoreBtn.addEventListener('click', function () {
@@ -53,8 +52,8 @@
           wrapper.style.overflow = isExpanded ? 'scroll' : 'unset'
           readMoreBtn.innerText = isExpanded
             ? (contentType === 'table'
-              ? 'Show full table' : 'View more code') : (contentType === 'table'
-              ? 'Hide full table' : 'View less code')
+              ? 'Expand table' : 'Expand code block') : (contentType === 'table'
+              ? 'Reduce table height' : 'Reduce code height')
           readMoreBtn.setAttribute('aria-expanded', !isExpanded)
 
           window.localStorage.setItem(key, !isExpanded)

--- a/src/partials/editable-placeholders-script.hbs
+++ b/src/partials/editable-placeholders-script.hbs
@@ -58,16 +58,19 @@ function addEditableSpan(regex, element) {
 }
 
 function addConumSpans(element) {
-  if (!element || !element.textContent) {
-      return;
-  }
-  let codeContent = element.innerHTML;
-
-  // Find numbers inside brackets at the end of lines
-  let pattern = /<span class="token punctuation">\(<\/span><span class="token number">(\d+)<\/span><span class="token punctuation">\)<\/span>\s*$/gm;
-  let replaced = codeContent.replace(pattern, '<i class="conum" data-value="$1"></i>');
-  element.innerHTML = replaced;
+    if (!element || !element.textContent) {
+        return;
+    }
+    let codeContent = element.innerHTML;
+    let pattern = /(\(<span class="token number">(\d+)<\/span>\)|\((\d+)\))\s*$/gm;
+    let replaced = codeContent.replace(pattern, function(match, p1, p2, p3) {
+        // Determine which group captured the digit, and use it for the data-value.
+        let digit = p2 || p3;
+        return `<i class="conum" data-value="${digit}"></i>`;
+    });
+    element.innerHTML = replaced;
 }
+
 
 
 function removeCursor(element) {


### PR DESCRIPTION
- Allows writers to display code snippets side by side for use in comparisons.

- Sets the default to expand all tables/code examples with the option to reduce the height.

- Improves the regex that supports Asciidoc callout in code blocks.

![2024-04-12_17-48-58](https://github.com/redpanda-data/docs-ui/assets/45230295/0f8d7616-a9eb-4f9f-b9a3-0eb4a596b7c3)

Example markup:

```
[.side-by-side]
--
.Strimzi
[source,yaml]
----
apiVersion: kafka.strimzi.io/v1beta2
kind: KafkaTopic
metadata:
  name: my-topic <1>
  labels:
    strimzi.io/cluster: my-kafka-cluster <2>
spec:
  partitions: 3 <3>
  replicas: 3 <4>
----

.Redpanda
[source,yaml]
----
apiVersion: cluster.redpanda.com/v1alpha1
kind: Topic
metadata:
  name: my-topic <1>
spec:
  kafkaApiSpec: <2>
    brokers:
      - "redpanda-0.redpanda.<namespace>.svc.cluster.local:9093"
      - "redpanda-1.redpanda.<namespace>.svc.cluster.local:9093"
      - "redpanda-2.redpanda.<namespace>.svc.cluster.local:9093"
    tls:
      caCertSecretRef:
        name: "redpanda-default-cert"
        key: "ca.crt"
  partitions: 3 <3>
  replicationFactor: 3 <4>
----
--
```
