### PR TITLE
Remove local storage for expand/reduce tables

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -1265,7 +1265,7 @@ html[data-theme=dark] code[class*=language-] .token.function {
 }
 
 .doc .colist {
-  font-size: calc(17 / var(--rem-base) * 1rem);
+  font-size: calc(19 / var(--rem-base) * 1rem);
   margin: 0.25rem 0 -0.25rem;
 }
 

--- a/src/js/14-find-large-tables-and-code-blocks.js
+++ b/src/js/14-find-large-tables-and-code-blocks.js
@@ -2,75 +2,84 @@
   'use strict'
   document.addEventListener('DOMContentLoaded', function () {
     const tables = document.querySelectorAll('table.tableblock:not(.no-clip)')
-    const codeBlocks = document.querySelectorAll('pre')
+    const codeBlocks = document.querySelectorAll('listingblock:not(.no-clip) pre')
+    const allElements = [...tables, ...codeBlocks]
 
-    const processElement = (element, contentType) => {
-      // If the element is a table and has the "no-clip" class, return early without processing
-      if (contentType === 'table' && element.classList.contains('no-clip')) {
-        return
-      }
-
-      const height = element.getBoundingClientRect().height
-      if (height > 1000) {
+    allElements.forEach((element, index) => {
+      if (element.getBoundingClientRect().height > 1000) {
         const wrapper = document.createElement('div')
         wrapper.className = 'clippedcontainer'
+        wrapper.id = `content-wrapper-${index}`
         element.parentNode.insertBefore(wrapper, element)
         wrapper.appendChild(element)
         wrapper.style.overflow = 'scroll'
         wrapper.style.transition = 'max-height 0.5s ease'
+        wrapper.style.maxHeight = '400px'
 
-        // Create a new container for the button with flex styling
         const buttonContainer = document.createElement('div')
         buttonContainer.style.display = 'flex'
         buttonContainer.style.justifyContent = 'flex-end'
         buttonContainer.style.marginTop = '-10px'
 
-        const readMoreBtn = document.createElement('button')
-        readMoreBtn.innerText = contentType === 'table' ? 'Reduce table height' : 'Reduce code height'
-        readMoreBtn.className = 'badge-button'
-        readMoreBtn.setAttribute('aria-expanded', 'true')
-        readMoreBtn.setAttribute('role', 'button')
-        readMoreBtn.setAttribute('tabindex', '0')
+        const expandBtn = document.createElement('button')
+        expandBtn.innerText = 'Expand'
+        expandBtn.className = 'badge-button'
+        expandBtn.setAttribute('aria-expanded', 'false')
+        expandBtn.setAttribute('aria-controls', wrapper.id)
+        expandBtn.setAttribute('role', 'button')
+        expandBtn.setAttribute('tabindex', '0')
 
-        // Append the button to the new container
-        buttonContainer.appendChild(readMoreBtn)
-
-        // Insert the button container after the wrapper
+        buttonContainer.appendChild(expandBtn)
         wrapper.parentNode.insertBefore(buttonContainer, wrapper.nextSibling)
 
-        const key = `expand-state-${contentType}-${Array.from(wrapper.parentNode.children).indexOf(wrapper)}`
-        const storedState = window.localStorage.getItem(key)
-        if (storedState === 'true') {
-          wrapper.style.maxHeight = `${element.scrollHeight}px`
-          readMoreBtn.innerText = contentType === 'table' ? 'Expand table' : 'Expand code block'
-          readMoreBtn.setAttribute('aria-expanded', 'false')
-        }
-
-        readMoreBtn.addEventListener('click', function () {
-          const isExpanded = readMoreBtn.getAttribute('aria-expanded') === 'true'
-          wrapper.style.maxHeight = isExpanded ? '400px' : `${element.scrollHeight}px`
-          wrapper.style.overflow = isExpanded ? 'scroll' : 'unset'
-          readMoreBtn.innerText = isExpanded
-            ? (contentType === 'table'
-              ? 'Expand table' : 'Expand code block') : (contentType === 'table'
-              ? 'Reduce table height' : 'Reduce code height')
-          readMoreBtn.setAttribute('aria-expanded', !isExpanded)
-
-          window.localStorage.setItem(key, !isExpanded)
-
-          if (isExpanded) {
-            const headerHeight = document.querySelector('#brand').offsetHeight
-            const topPos = wrapper.getBoundingClientRect().top + window.scrollY - headerHeight
-            window.scrollTo({
-              top: topPos,
-              behavior: 'smooth',
-            })
+        expandBtn.addEventListener('keydown', function (event) {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault()
+            expandBtn.click()
           }
         })
       }
+    })
+
+    allElements.forEach((element) => {
+      const wrapper = element.closest('.clippedcontainer')
+      if (wrapper) {
+        const button = wrapper.nextSibling.querySelector('button')
+        adjustElement(wrapper, button, true)
+      }
+    })
+
+    document.querySelectorAll('.badge-button').forEach((button) => {
+      button.addEventListener('click', () => {
+        const newState = button.getAttribute('aria-expanded') === 'false'
+        const wrapper = button.closest('div').previousSibling // Find the associated wrapper
+        adjustElement(wrapper, button, newState)
+        // Scroll to keep the wrapper visible
+        scrollToTopOfWrapper(wrapper)
+      })
+    })
+
+    function adjustElement (wrapper, button, expand) {
+      const element = wrapper.firstChild
+      wrapper.style.maxHeight = expand ? `${element.scrollHeight}px` : '400px'
+      button.innerText = expand ? 'Reduce' : 'Expand'
+      button.setAttribute('aria-expanded', expand)
+      wrapper.style.overflow = expand ? 'unset' : 'scroll'
     }
 
-    tables.forEach((table) => processElement(table, 'table'))
-    codeBlocks.forEach((codeBlock) => processElement(codeBlock, 'code'))
+    function scrollToTopOfWrapper (wrapper) {
+      // Obtain the height of the toolbar and navbar, defaulting to 0 if they are not found
+      const toolbarHeight = document.querySelector('.toolbar') ? document.querySelector('.toolbar').offsetHeight : 0
+      const navbarHeight = document.querySelector('.navbar') ? document.querySelector('.navbar').offsetHeight : 0
+      // Calculate the total offset height including both the toolbar and navbar
+      const totalOffsetHeight = toolbarHeight + navbarHeight
+      // Calculate the top position by considering the total offset height
+      const topPosition = wrapper.getBoundingClientRect().top + window.scrollY - totalOffsetHeight
+      // Scroll to the calculated position smoothly
+      window.scrollTo({
+        top: topPosition,
+        behavior: 'smooth',
+      })
+    }
   })
 })()

--- a/src/js/14-find-large-tables-and-code-blocks.js
+++ b/src/js/14-find-large-tables-and-code-blocks.js
@@ -15,6 +15,8 @@
         wrapper.style.overflow = 'scroll'
         wrapper.style.transition = 'max-height 0.5s ease'
         wrapper.style.maxHeight = '400px'
+        wrapper.style.marginTop = '1.5em'
+        element.style.marginTop = 'unset'
 
         const buttonContainer = document.createElement('div')
         buttonContainer.style.display = 'flex'


### PR DESCRIPTION
The localstorage keys were not unique across pages so users ended up with some tables/code blocks expanded and others clipped on page load.

This PR removes the local storage so that all tables/code blocks are expanded by default (so no information is missed), and users have the option to clip the height of selected tables after reading.