### PR TITLE
API doc updates and editable placeholder improvements

### DIFF
--- a/src/css/editable-placeholders.css
+++ b/src/css/editable-placeholders.css
@@ -7,6 +7,13 @@ span.editable {
   margin-left: 1px;
   margin-right: 1px;
   background: var(--editable-background);
+  border-bottom: 2px dashed;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+span.editable:hover {
+  cursor: pointer;
 }
 
 span.cursor {
@@ -15,6 +22,7 @@ span.cursor {
   left: -9px;
   position: relative;
   display: inline-block;
+  font-size: 1.1em;
   width: 0;
 }
 
@@ -22,7 +30,7 @@ span.cursor::after,
 span.cursor > span::after {
   content: "|";
   display: inline-block;
-  animation: cursor-blink 1.2s infinite;
+  animation: cursor-blink 1.1s infinite;
   font-weight: 100;
   color: var(--editable-code-font-color);
 }

--- a/src/css/swagger.css
+++ b/src/css/swagger.css
@@ -5,7 +5,6 @@
 
 .swagger {
   color: var(--body-font-color);
-  font-size: var(--body-font-size);
   hyphens: auto;
   line-height: var(--doc-line-height);
   padding: 0 1rem;

--- a/src/css/swagger.css
+++ b/src/css/swagger.css
@@ -5,9 +5,9 @@
 
 .swagger {
   color: var(--body-font-color);
-  font-size: var(--swagger-font-size);
+  font-size: var(--body-font-size);
   hyphens: auto;
-  line-height: var(--swagger-line-height);
+  line-height: var(--doc-line-height);
   padding: 0 1rem;
   margin-top: 2.5rem;
 }

--- a/src/css/swagger.css
+++ b/src/css/swagger.css
@@ -1,12 +1,228 @@
-.information-container.wrapper {
-  display: none !important;
-}
-
-.swagger-ui .wrapper {
-  padding: 0 !important;
-}
-
 .opblock-summary-path {
   max-width: none !important;
   flex-shrink: unset !important;
+}
+
+.swagger {
+  color: var(--body-font-color);
+  font-size: var(--swagger-font-size);
+  hyphens: auto;
+  line-height: var(--swagger-line-height);
+  padding: 0 1rem;
+  margin-top: 2.5rem;
+}
+
+.swagger a,
+.swagger .glossary-term,
+.swagger p a > code {
+  color: var(--link-font-color);
+}
+
+.swagger a:hover,
+.swagger .glossary-term:hover,
+.swagger p a > code:hover {
+  color: var(--link_hover-font-color);
+}
+
+.swagger code,
+.swagger pre {
+  hyphens: none;
+  color: var(--code-font-color);
+  background: var(--pre-background);
+}
+
+.swagger p code,
+.swagger code,
+.swagger thead code,
+.swagger .colist > table code {
+  color: var(--code-font-color);
+  background: var(--code-background);
+  border: 0.1rem solid #0000001a;
+  font-weight: lighter;
+  border-radius: 0.25em;
+  font-size: 0.88rem;
+  padding: 0.125em 0.25em;
+}
+
+/* Override Prism.js styles */
+.swagger code .token.operator,
+.swagger code .token.url {
+  background-color: inherit;
+}
+
+.swagger pre {
+  font-size: calc(16 / var(--rem-base) * 1rem);
+  line-height: 1.5;
+  margin: 0;
+  padding: 1em;
+}
+
+.swagger pre > code {
+  padding-bottom: 1rem;
+  border: none;
+  white-space: pre-wrap;
+  font-weight: lighter;
+}
+
+.swagger pre > code span {
+  position: relative;
+  z-index: 1;
+}
+
+.swagger .paragraph,
+.swagger .dlist,
+.swagger .hdlist,
+.swagger .olist,
+.swagger .ulist,
+.swagger .exampleblock,
+.swagger .imageblock,
+.swagger .listingblock,
+.swagger .literalblock,
+.swagger .sidebarblock,
+.swagger .verseblock,
+.swagger .videoblock,
+.swagger .quoteblock,
+.swagger .partintro,
+.swagger details,
+.swagger hr {
+  margin: 1rem 0 0;
+}
+
+.swagger .ulist.two-column {
+  column-count: 2;
+}
+
+.swagger table.tableblock {
+  font-size: calc(17 / var(--rem-base) * 1rem);
+}
+
+.tablecontainer {
+  overflow-x: auto;
+}
+
+.swagger .clippedcontainer table.tableblock thead {
+  background: var(--sticky-table-header-background);
+  position: sticky;
+  top: -1px;
+  z-index: var(--z-index-nav);
+}
+
+.content .tablecontainer {
+  margin-bottom: 1.25em;
+}
+
+.content .tablecontainer > table.tableblock {
+  margin-bottom: 0;
+}
+
+.swagger :not(.tablecontainer) > table.tableblock,
+.swagger :not(.tablecontainer) > table.tableblock + * {
+  margin-top: 1.5rem;
+}
+
+.swagger p.tableblock + p.tableblock {
+  margin-top: 0.5rem;
+}
+
+.swagger td.tableblock > .content > :first-child {
+  margin-top: 0;
+}
+
+.swagger table.tableblock th,
+.swagger table.tableblock td {
+  padding: 0.5rem;
+}
+
+.swagger table.tableblock,
+.swagger table.tableblock > * > tr > * {
+  border: 1px solid var(--table-border-color);
+}
+
+.swagger table.tableblock th {
+  text-align: center;
+}
+
+.swagger table.grid-all > * > tr > * {
+  border-width: 1px;
+}
+
+.swagger table.grid-cols > * > tr > * {
+  border-width: 0 1px;
+}
+
+.swagger table.grid-rows > * > tr > * {
+  border-width: 1px 0;
+}
+
+.swagger table.grid-all > thead th,
+.swagger table.grid-rows > thead th {
+  border-bottom-width: 2.5px;
+}
+
+.swagger table.frame-all {
+  border-width: 1px;
+}
+
+.swagger table.frame-ends {
+  border-width: 1px 0;
+}
+
+.swagger table.frame-sides {
+  border-width: 0 1px;
+}
+
+.swagger table.frame-none > colgroup + * > :first-child > *,
+.swagger table.frame-sides > colgroup + * > :first-child > * {
+  border-top-width: 0;
+}
+
+/* NOTE let the grid win in case of frame-none */
+.swagger table.frame-sides > :last-child > :last-child > * {
+  border-bottom-width: 0;
+}
+
+.swagger table.frame-none > * > tr > :first-child,
+.swagger table.frame-ends > * > tr > :first-child {
+  border-left-width: 0;
+}
+
+.swagger table.frame-none > * > tr > :last-child,
+.swagger table.frame-ends > * > tr > :last-child {
+  border-right-width: 0;
+}
+
+.swagger table.stripes-all > tbody > tr,
+.swagger table.stripes-odd > tbody > tr:nth-of-type(odd),
+.swagger table.stripes-even > tbody > tr:nth-of-type(even),
+.swagger table.stripes-hover > tbody > tr:hover,
+.swagger table.tableblock thead {
+  background: var(--table-stripe-background);
+}
+
+.swagger table.tableblock > tfoot {
+  background: var(--table-footer-background);
+}
+
+.swagger .halign-left {
+  text-align: left;
+}
+
+.swagger .halign-right {
+  text-align: right;
+}
+
+.swagger .halign-center {
+  text-align: center;
+}
+
+.swagger .valign-top {
+  vertical-align: top;
+}
+
+.swagger .valign-bottom {
+  vertical-align: bottom;
+}
+
+.swagger .valign-middle {
+  vertical-align: middle;
 }

--- a/src/helpers/get-api-slots.js
+++ b/src/helpers/get-api-slots.js
@@ -18,7 +18,7 @@ module.exports = (url, slot, { data: { root } }) => {
 
   // Decode the Buffer to string for the HTML content
   const contentBuffer = Buffer.from(filteredPage._contents)
-  let decodedContent = contentBuffer.toString('utf8')
+  const decodedContent = contentBuffer.toString('utf8')
 
   // Return the HTML content.
   return decodedContent

--- a/src/helpers/get-api-slots.js
+++ b/src/helpers/get-api-slots.js
@@ -15,11 +15,18 @@ module.exports = (url, slot, { data: { root } }) => {
   })
 
   if (!filteredPage) return null
+  console.log(JSON.stringify(filteredPage))
 
+  function removeRelativeLinkTags (htmlContent) {
+    const regex = /<a\s+(?:[^>]*?\s+)?href="(?!(http:\/\/|https:\/\/))([^"]*)"(?:[^>]*)>(.*?)<\/a>/gis
+    // Replace the matched <a> tags with just their text content
+    return htmlContent.replace(regex, '$3')
+  }
   // Decode the Buffer to string for the HTML content
   const contentBuffer = Buffer.from(filteredPage._contents)
   const decodedContent = contentBuffer.toString('utf8')
+  const cleanedContent = removeRelativeLinkTags(decodedContent)
 
   // Return the HTML content.
-  return decodedContent
+  return cleanedContent
 }

--- a/src/helpers/get-api-slots.js
+++ b/src/helpers/get-api-slots.js
@@ -1,0 +1,25 @@
+'use strict'
+
+module.exports = (url, slot, { data: { root } }) => {
+  const { contentCatalog } = root
+  if (!contentCatalog) return null
+
+  const pages = contentCatalog.findBy({ component: 'ROOT', family: 'page' })
+
+  // Find the first page that matches the 'page-api' in the URL and the 'page-api-slot' matching the slot.
+  const filteredPage = pages.find((page) => {
+    const attributes = page.asciidoc.attributes
+    return attributes['page-api'] &&
+           url.includes(attributes['page-api']) &&
+           attributes['page-api-slot'] === slot
+  })
+
+  if (!filteredPage) return null
+
+  // Decode the Buffer to string for the HTML content
+  const contentBuffer = Buffer.from(filteredPage._contents)
+  let decodedContent = contentBuffer.toString('utf8')
+
+  // Return the HTML content.
+  return decodedContent
+}

--- a/src/helpers/iso-date.js
+++ b/src/helpers/iso-date.js
@@ -1,0 +1,7 @@
+'use strict'
+
+module.exports = () => {
+  const today = new Date()
+  // Returns date in YYYY-MM-DD format
+  return today.toISOString().substring(0, 10)
+}

--- a/src/js/06-copy-to-clipboard.js
+++ b/src/js/06-copy-to-clipboard.js
@@ -10,6 +10,9 @@
   var svgAs = config.svgAs
   var supportsCopy = window.navigator.clipboard
 
+  // We use Rapidoc for the API docs, which comes with a copy button already.
+  if (document.querySelectorAll('.body.swagger').length > 0) return
+
   document.querySelectorAll('pre').forEach(function (pre) {
     if (pre.firstElementChild && pre.firstElementChild.tagName.toLowerCase() === 'code') {
       pre.classList.add('code-first-child')

--- a/src/layouts/swagger.hbs
+++ b/src/layouts/swagger.hbs
@@ -8,7 +8,7 @@
   </head>
   <body class="body swagger" style="padding-top:0; height:100vh;">
     <rapi-doc id="api" spec-url="{{resolve-resource page.attributes.api-spec-url}}" primary-color="#e2401b"
-        show-header=false {{#if page.attributes.try-it}}allow-try=true {{else}} allow-try=false {{/if}} show-curl-before-try=true show-method-in-nav-bar="as-colored-block" show-info="true" render-style="read" regular-font="'Calibre Regular', 'Open Sans', arial, helvetica, sans-serif" fill-request-fields-with-example="false" nav-bg-color="#fff"  bg-color="#fff" nav-item-spacing="relaxed" font-size="largest" fetch-credentials="include">
+        show-header=false {{#if page.attributes.try-it}}allow-try=true {{else}} allow-try=false {{/if}} show-curl-before-try=true show-method-in-nav-bar="as-colored-block" show-info="true" render-style="read" regular-font="'Calibre Regular', 'Open Sans', arial, helvetica, sans-serif" fill-request-fields-with-example="true" nav-bg-color="#fff"  bg-color="#fff" nav-item-spacing="relaxed" font-size="largest" fetch-credentials="include" css-file="{{{uiRootPath}}}/css/site.css"  css-classes="swagger">
     <div class="toolbar" role="navigation" style="top:0;">
       {{#with site.homeUrl}}
       {{#if (ne @root.page.component.name 'redpanda-labs')}}
@@ -24,6 +24,16 @@
     </div>
     <div slot="nav-logo" style="display: flex; align-items: center; justify-content: center;">
       <a class="navbar-item" href="{{{or site.url siteRootPath}}}" aria-label="Go to home page"><img src="{{{uiRootPath}}}/img/redpanda-docs-logo.svg" width="250px" height= "30px" alt="Redpanda logo"/></a>
+    </div>
+    <div slot="overview">
+      {{#with (get-api-slots page.url 'overview')}}
+          {{{this}}}
+      {{/with}}
+    </div>
+    <div slot="auth">
+      {{#with (get-api-slots page.url 'auth')}}
+          {{{this}}}
+      {{/with}}
     </div>
     <div slot="footer">
       {{> footer}}
@@ -55,6 +65,29 @@
                     targetElement.style.display = 'none';
                     observer.disconnect();
                   }
+                  const subTitleDivs = node.querySelectorAll('.sub-title');
+                  subTitleDivs.forEach(div => {
+                    const h2 = document.createElement('h2');
+                    h2.innerHTML = div.innerHTML;
+                    const partAttribute = div.getAttribute('part');
+                    if (partAttribute) {
+                      h2.setAttribute('part', partAttribute);
+                    }
+                    div.parentNode.replaceChild(h2, div);
+                  });
+                  const headingElements = Array.from(node.querySelectorAll('h2:not(div.sect > h2), h3:not(div.sect > h3), h4:not(div.sect > h4)'));
+                  headingElements.forEach(heading => {
+                    if (!heading.closest('.sect')) {
+                      heading.style.fontSize = 'revert';
+                      heading.style.paddingTop = 'revert';
+                      heading.style.marginBlockEnd = 'revert';
+                    }
+                  });
+                  const tables = node.querySelectorAll('table');
+                  tables.forEach(table => {
+                    table.classList.add('tableblock', 'stripes-odd');
+                    table.style.width = '100%';
+                  });
                 }
               });
             });

--- a/src/partials/editable-placeholders-script.hbs
+++ b/src/partials/editable-placeholders-script.hbs
@@ -120,6 +120,15 @@ function addEvents(parentElement) {
         }
       });
     });
+    // Handle the Enter key
+    placeholder.addEventListener('keydown', function(event) {
+      if (event.key === 'Enter') {
+        // Prevent the default Enter key behavior (newline)
+        event.preventDefault()
+        // Exit the editable mode and move the focus out
+        event.target.blur()
+      }
+    });
   })
 }
 

--- a/src/partials/editable-placeholders-script.hbs
+++ b/src/partials/editable-placeholders-script.hbs
@@ -129,6 +129,23 @@ function addEvents(parentElement) {
         event.target.blur()
       }
     });
+    placeholder.addEventListener('blur', function() {
+      const currentText = this.textContent.trim();
+      const dataType = this.getAttribute('data-type');
+      if (currentText) {
+        sessionStorage.setItem(dataType, currentText);
+      } else {
+        // Reset to default
+        this.textContent = `<${dataType}>`;
+      }
+    });
+    const dataType = placeholder.getAttribute('data-type')
+    if (!dataType) {
+      console.error('Data type attribute is missing on the placeholder.')
+      return
+    }
+    const savedText = sessionStorage.getItem(dataType);
+    placeholder.textContent = savedText ? savedText : `<${dataType}>`;
   })
 }
 

--- a/src/partials/head-meta.hbs
+++ b/src/partials/head-meta.hbs
@@ -5,3 +5,4 @@
 {{#with site.components.ROOT}}
 <meta name="latest-redpanda-version" content="{{this.latest.version}}">
 {{/with}}
+<meta itemprop="datePublished" content="{{iso-date}}">


### PR DESCRIPTION
- Fixes https://github.com/redpanda-data/documentation-private/issues/2119 - User values are saved to session storage. If the user deletes the whole placeholder, it is not saved and the original is put back. Try it here: https://deploy-preview-167--docs-ui.netlify.app/#cu-solet

- Fixes https://github.com/redpanda-data/documentation-private/issues/2383 Try it here: https://deploy-preview-167--docs-ui.netlify.app/#cu-solet

- Fixes https://github.com/redpanda-data/documentation-private/issues/2380

This PR also adds support for integrating Redpanda documentation within the Rapidoc API pages by dynamically retrieving and rendering content based on metadata defined by the writers. This allows for seamless inclusion of targeted documentation directly into API reference pages, enriching the API documentation with relevant conceptual, setup, or usage information.

To use this feature:

Ensure that pages you want to include in API reference docs are tagged with `page-api` and `page-api-slot` attributes. Here’s an example of how to set these attributes in an AsciiDoc file:

```asciidoc
= My API Guide
:page-api: <api-name>
:page-api-slot: <slot>
```

- `<api-name>` is the name of the API. This is used to determine in which API reference to put the content.

- `<page-api-slot>` is the name of the [Rapidoc slot](https://rapidocweb.com/api.html#slots) to put this content in. The only supported slots at the moment are `overview` and `auth`.

**Benefits:**
- Allows documentation to be integrated within API references, providing users with a richer understanding directly in the API documentation.

- Streamlines content updates as documentation can be maintained in one place within Antora and dynamically pulled into Rapidoc as needed.