### PR TITLE
Fix the api-slots to strip content

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -216,11 +216,6 @@
   font-weight: lighter;
 }
 
-.doc pre > code span {
-  position: relative;
-  z-index: 1;
-}
-
 .doc blockquote {
   margin: 0;
 }

--- a/src/css/editable-placeholders.css
+++ b/src/css/editable-placeholders.css
@@ -19,28 +19,5 @@ span.editable:hover {
 span.cursor {
   font-weight: 450;
   color: var(--editable-code-font-color);
-  left: -9px;
-  position: relative;
-  display: inline-block;
   font-size: 1.1em;
-  width: 0;
-}
-
-span.cursor::after,
-span.cursor > span::after {
-  content: "|";
-  display: inline-block;
-  animation: cursor-blink 1.1s infinite;
-  font-weight: 100;
-  color: var(--editable-code-font-color);
-}
-
-@keyframes cursor-blink {
-  from {
-    opacity: 1;
-  }
-
-  to {
-    opacity: 0;
-  }
 }

--- a/src/helpers/get-api-slots.js
+++ b/src/helpers/get-api-slots.js
@@ -15,17 +15,36 @@ module.exports = (url, slot, { data: { root } }) => {
   })
 
   if (!filteredPage) return null
-  console.log(JSON.stringify(filteredPage))
 
   function removeRelativeLinkTags (htmlContent) {
     const regex = /<a\s+(?:[^>]*?\s+)?href="(?!(http:\/\/|https:\/\/))([^"]*)"(?:[^>]*)>(.*?)<\/a>/gis
     // Replace the matched <a> tags with just their text content
     return htmlContent.replace(regex, '$3')
   }
+  function extractDocContent (htmlContent) {
+    // Regular expression to find the <article class="doc">...</article> block
+    const articleRegex = /<article\s+class="doc"[^>]*>([\s\S]*?)<\/article>/
+    const match = htmlContent.match(articleRegex)
+
+    if (!match) return ''
+
+    // Extract content inside the article
+    let articleContent = match[1]
+    // Remove unnecessary elements
+    articleContent = articleContent.replace(/<nav[^>]*>[\s\S]*?<\/nav>/g, '')
+    articleContent = articleContent.replace(/<[^>]+class="[^"]*feedback-section[^"]*"[^>]*>[\s\S]*?<\/[^>]+>/g, '')
+    articleContent = articleContent.replace(/<div[^>]*class="[^"]*col[^"]*"[^>]*>[\s\S]*?<\/div>/g, '')
+    articleContent = articleContent.replace(/<h1[^>]*>[\s\S]*?<\/h1>/g, '')
+    articleContent = articleContent.replace(/<button[^>]*class="[^"]*thumb[^"]*"[^>]*>[\s\S]*?<\/button>/g, '')
+
+    const cleanedContent = removeRelativeLinkTags(articleContent)
+
+    return cleanedContent
+  }
   // Decode the Buffer to string for the HTML content
   const contentBuffer = Buffer.from(filteredPage._contents)
   const decodedContent = contentBuffer.toString('utf8')
-  const cleanedContent = removeRelativeLinkTags(decodedContent)
+  const cleanedContent = extractDocContent(decodedContent)
 
   // Return the HTML content.
   return cleanedContent

--- a/src/partials/editable-placeholders-script.hbs
+++ b/src/partials/editable-placeholders-script.hbs
@@ -51,7 +51,7 @@ function addEditableSpan(regex, element) {
     }
     const regexString = RegExp.escape(placeholder);
     const globalRegex = new RegExp(regexString, 'g');
-    newHTML = newHTML.replace(globalRegex, `<span contenteditable="true" data-type="${cleanedPlaceholder}" onclick="removeCursor(event)">&lt;${cleanedPlaceholder}&gt;</span><span class="cursor"></span>`);
+    newHTML = newHTML.replace(globalRegex, `<span contenteditable="true" data-type="${cleanedPlaceholder}">&lt;${cleanedPlaceholder}&gt;</span><span class="fa fa-pencil cursor"></span>`);
     processed.add(placeholder);
   }
   element.innerHTML = newHTML;
@@ -71,19 +71,6 @@ function addConumSpans(element) {
     element.innerHTML = replaced;
 }
 
-
-
-function removeCursor(element) {
-  if (element.target) {
-    element = element.target;
-  }
-
-  if (element.contentEditable === 'true' && element.nextElementSibling) {
-    element.nextElementSibling.classList.remove('cursor');
-  } else if (element.parentElement && element.parentElement.nextElementSibling) {
-    element.parentElement.nextElementSibling.classList.remove('cursor');
-  }
-}
 
 function addClasses(parentElement) {
   const baseElement = parentElement || document;
@@ -116,7 +103,6 @@ function addEvents(parentElement) {
         // Update the text if the span isn't within a hidden tab
         if (!hasHiddenAncestor && span !== event.target) {
             span.textContent = newText
-            removeCursor(span)
         }
       });
     });
@@ -130,6 +116,10 @@ function addEvents(parentElement) {
       }
     });
     placeholder.addEventListener('blur', function() {
+      const cursor = this.nextElementSibling;
+      if (cursor && cursor.classList.contains('cursor')) {
+        cursor.style.display = 'inline';
+      }
       const currentText = this.textContent.trim();
       const dataType = this.getAttribute('data-type');
       if (currentText) {
@@ -137,6 +127,12 @@ function addEvents(parentElement) {
       } else {
         // Reset to default
         this.textContent = `<${dataType}>`;
+      }
+    });
+    placeholder.addEventListener('focus', function() {
+    const cursor = this.nextElementSibling;
+      if (cursor && cursor.classList.contains('cursor')) {
+        cursor.style.display = 'none';
       }
     });
     const dataType = placeholder.getAttribute('data-type')


### PR DESCRIPTION
The api-slots helper fetched all HTML content from the docs, including the nav tree. We only want the main content. This PR strips the unnecessary HTML before including it in the API docs.

This PR also improves the editable placeholders by using a pencil for the icon instead of a flashing cursor, which is distracting. Preview: https://deploy-preview-168--docs-ui.netlify.app/#cu-solet