### PR TITLE
Improve support for injecting API slots

### DIFF
--- a/src/helpers/get-api-slots.js
+++ b/src/helpers/get-api-slots.js
@@ -1,51 +1,49 @@
 'use strict'
 
-module.exports = (url, slot, { data: { root } }) => {
-  const { contentCatalog } = root
+// Keep track of processed pages
+const processedPages = new Set()
+
+module.exports = (url, { data }) => {
+  const { contentCatalog } = data.root
   if (!contentCatalog) return null
 
-  const pages = contentCatalog.findBy({ component: 'ROOT', family: 'page' })
+  const pages = contentCatalog.findBy({ component: 'api', family: 'page' })
 
-  // Find the first page that matches the 'page-api' in the URL and the 'page-api-slot' matching the slot.
-  const filteredPage = pages.find((page) => {
-    const attributes = page.asciidoc.attributes
-    return attributes['page-api'] &&
-           url.includes(attributes['page-api']) &&
-           attributes['page-api-slot'] === slot
+  // Use filter to collect all matching pages
+  const filteredPages = pages.filter((page) => {
+    if (processedPages.has(page.src.relative)) {
+      // Skip this page if it has already been processed
+      return false
+    }
+
+    const pathParts = page.src.relative.split('/')
+    if (pathParts.length !== 3) return false
+
+     // Use the first directory as the API name
+    const api = pathParts[0]
+
+    if (url.includes(api)) {
+      processedPages.add(page.src.relative)
+      return true
+    }
+    return false
+  }).map((page) => {
+    // Process each page to convert its content and wrap it with the Rapidoc slot
+    // https://rapidocweb.com/api.html#slots
+    const contentBuffer = Buffer.from(page._contents)
+    const decodedContent = contentBuffer.toString('utf8')
+    // Use the second directory as the slot name
+    return wrapHtmlWithSlot(decodedContent, page.src.relative.split('/')[1])
   })
+  // Return the array of wrapped HTML content
+  return filteredPages
+}
 
-  if (!filteredPage) return null
-
-  function removeRelativeLinkTags (htmlContent) {
-    const regex = /<a\s+(?:[^>]*?\s+)?href="(?!(http:\/\/|https:\/\/))([^"]*)"(?:[^>]*)>(.*?)<\/a>/gis
-    // Replace the matched <a> tags with just their text content
-    return htmlContent.replace(regex, '$3')
+function wrapHtmlWithSlot (htmlContent, slotName) {
+  // Check if the slotName is 'auth' or 'overview'
+  if (slotName === 'auth' || slotName === 'overview') {
+    return `<div slot="${slotName}">${htmlContent}</div>`
   }
-  function extractDocContent (htmlContent) {
-    // Regular expression to find the <article class="doc">...</article> block
-    const articleRegex = /<article\s+class="doc"[^>]*>([\s\S]*?)<\/article>/
-    const match = htmlContent.match(articleRegex)
-
-    if (!match) return ''
-
-    // Extract content inside the article
-    let articleContent = match[1]
-    // Remove unnecessary elements
-    articleContent = articleContent.replace(/<nav[^>]*>[\s\S]*?<\/nav>/g, '')
-    articleContent = articleContent.replace(/<[^>]+class="[^"]*feedback-section[^"]*"[^>]*>[\s\S]*?<\/[^>]+>/g, '')
-    articleContent = articleContent.replace(/<div[^>]*class="[^"]*col[^"]*"[^>]*>[\s\S]*?<\/div>/g, '')
-    articleContent = articleContent.replace(/<h1[^>]*>[\s\S]*?<\/h1>/g, '')
-    articleContent = articleContent.replace(/<button[^>]*class="[^"]*thumb[^"]*"[^>]*>[\s\S]*?<\/button>/g, '')
-
-    const cleanedContent = removeRelativeLinkTags(articleContent)
-
-    return cleanedContent
-  }
-  // Decode the Buffer to string for the HTML content
-  const contentBuffer = Buffer.from(filteredPage._contents)
-  const decodedContent = contentBuffer.toString('utf8')
-  const cleanedContent = extractDocContent(decodedContent)
-
-  // Return the HTML content.
-  return cleanedContent
+  // Return the content without wrapping if the slot does not match
+  return htmlContent
 }

--- a/src/helpers/get-api-slots.js
+++ b/src/helpers/get-api-slots.js
@@ -19,7 +19,7 @@ module.exports = (url, { data }) => {
     const pathParts = page.src.relative.split('/')
     if (pathParts.length !== 3) return false
 
-     // Use the first directory as the API name
+    // Use the first directory as the API name
     const api = pathParts[0]
 
     if (url.includes(api)) {

--- a/src/layouts/api-partial.hbs
+++ b/src/layouts/api-partial.hbs
@@ -1,0 +1,8 @@
+<!-- Pages with this layout are never published -->
+<!DOCTYPE html>
+<html lang="en">
+  <meta name="robots" content="noindex">
+  <body>
+    <article class="doc"></article>
+  </body>
+</html>

--- a/src/layouts/swagger.hbs
+++ b/src/layouts/swagger.hbs
@@ -25,16 +25,9 @@
     <div slot="nav-logo" style="display: flex; align-items: center; justify-content: center;">
       <a class="navbar-item" href="{{{or site.url siteRootPath}}}" aria-label="Go to home page"><img src="{{{uiRootPath}}}/img/redpanda-docs-logo.svg" width="250px" height= "30px" alt="Redpanda logo"/></a>
     </div>
-    <div slot="overview">
-      {{#with (get-api-slots page.url 'overview')}}
-          {{{this}}}
-      {{/with}}
-    </div>
-    <div slot="auth">
-      {{#with (get-api-slots page.url 'auth')}}
-          {{{this}}}
-      {{/with}}
-    </div>
+    {{#each (get-api-slots page.url)}}
+        {{{this}}}
+    {{/each}}
     <div slot="footer">
       {{> footer}}
     </div>


### PR DESCRIPTION
With this change, we support two Rapidoc slots `overview` and `auth`.

To get content into these slots, create Asciidoc pages in the following directory structure in the `api` component:

`modules/ROOT/pages/<api>/<slot>/filename.adoc`

For example: `modules/ROOT/pages/cloud/overview/make-request.adoc`

We pick up the content in that file, convert it to HTML, and inject it into the corresponding slot in Rapidoc.
You can include content from Redpanda docs into those files, if necessary.