### PR TITLE
force white bg to lens images

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -602,6 +602,7 @@ table code {
   height: auto;
   max-width: 100%;
   vertical-align: middle;
+  background: white;
 }
 
 .doc .image:not(.left):not(.right) > img {


### PR DESCRIPTION
Resolves https://github.com/redpanda-data/documentation-private/issues/2439

This forces a white bg to all lens images. 

Regarding dark mode, our current images don't look good with a dark background. Whenever this is revisted, we can change this to actual var values.