### PR TITLE
Skip editable placeholders on request

### DIFF
--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -237,6 +237,14 @@ Here we just have some plain text.
 plain text
 ----
 
+
+==== Ignored placeholders
+
+[source,bash,role="no-placeholders"]
+----
+<this-placeholder-will-be-unchanged>
+----
+
 ==== Side-by-side code
 
 [.side-by-side]

--- a/src/partials/editable-placeholders-script.hbs
+++ b/src/partials/editable-placeholders-script.hbs
@@ -12,9 +12,17 @@ function createEditablePlaceholders(parentElement) {
 
   for (let i = 0; i < codeElements.length; i++) {
     const codeElement = codeElements[i];
+    const preElement = codeElement.parentElement;
+    const contentDivElement = preElement.parentElement;
+    const listingBlockElement = contentDivElement.parentElement;
+
+    // Check if the grandparent has the class 'no-placeholders'
+    if (listingBlockElement.classList.contains('no-placeholders')) {
+      continue;
+    }
     preprocessParentheses(codeElement)
     addConumSpans(codeElement);
-    if(codeElement.dataset.lang !== 'xml' && codeElement.dataset.lang !== 'html' && codeElement.dataset.lang !== 'rust') {
+    if(codeElement.dataset.lang !== 'xml' && codeElement.dataset.lang !== 'html' && codeElement.dataset.lang !== 'rust' && codeElement.dataset.lang !== 'coffeescript') {
       addEditableSpan(/&lt;.[^&A-Z]+&gt;/g, codeElement);
     }
   }
@@ -87,7 +95,7 @@ function addConumSpans(element) {
         return;
     }
     let codeContent = element.innerHTML;
-    let pattern = /(\(<span class="token number">(\d+)<\/span>\)|\((\d+)\))\s*$/gm;
+    let pattern = /\s(\(<span class="token number">(\d+)<\/span>\)|\((\d+)\))\s*$/gm;
     let replaced = codeContent.replace(pattern, function(match, p1, p2, p3) {
         // Determine which group captured the digit, and use it for the data-value.
         let digit = p2 || p3;


### PR DESCRIPTION
Allows writers to define code blocks with editable placeholder syntax that should be left unchanged.

This PR also adds `coffeescript` to the list of languages we ignore because Bloblang uses this syntax highlighter and includes our editable placeholder syntax.

```asciidoc
[source,bash,role="no-placeholders"]
----
<this-placeholder-will-be-unchanged>
----
```