### PR TITLE
Fix rapidoc styles

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -3,5 +3,6 @@
   "rules": {
     "comment-empty-line-before": null,
     "no-descending-specificity": null,
+    "selector-type-no-unknown": null
   }
 }

--- a/src/css/breadcrumbs.css
+++ b/src/css/breadcrumbs.css
@@ -30,7 +30,7 @@ a + .breadcrumbs {
 }
 
 .breadcrumbs li::after {
-  content: ">";
+  content: "\203A";
   padding: 0 0.5rem;
 }
 
@@ -44,8 +44,8 @@ a + .breadcrumbs {
 
 .breadcrumbs li:hover a,
 .breadcrumbs li:last-child a {
-  background-color: var(--link-highlight-background-color);
   color: var(--link-font-color);
   border-radius: 1.5rem;
+  padding: 0;
   text-decoration: none;
 }

--- a/src/css/cloud-api-feedback.css
+++ b/src/css/cloud-api-feedback.css
@@ -6,6 +6,7 @@
   flex-direction: column;
   color: var(--link-font-color);
   gap: 10px;
+  margin-top: -1rem;
 }
 
 .cloud-api-feedback-section .material-icons {

--- a/src/css/dark-mode.css
+++ b/src/css/dark-mode.css
@@ -24,12 +24,12 @@ html[data-theme=dark] {
   --navbar-menu-background: var(--body-background);
   --navbar-menu-font-color: var(--body-font-color);
   --navbar-menu_hover-background: none;
-  --navbar-boxshadow: 1px 3px 5px #f2f2f2;
+  --navbar-boxshadow: 1px 3px 5px rgba(16, 16, 16, 0.5);
   --navbar-dropdown-boxshadow: 0 4px 10px #f2f2f2;
   --navbar-dropdown-background-hover-color: #ffffff0d;
   /* nav */
   --nav-background: var(--body-background);
-  --nav-border-color: var(--color-gray-10);
+  --nav-border-color: rgba(0, 0, 0, 0.2);
   --nav-heading-font-color: var(--color-jet-30);
   --nav-muted-color: var(--body-font-color);
   --nav-panel-divider-color: var(--color-smoke-90);

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -12,7 +12,7 @@
   main {
     margin: 0 auto;
     width: calc(100% - var(--nav-width));
-    padding-top: 20px;
+    padding-top: 0;
     min-width: 0; /* min-width: 0 required for flexbox to constrain overflowing elements */
   }
 

--- a/src/css/swagger.css
+++ b/src/css/swagger.css
@@ -7,8 +7,11 @@
   color: var(--body-font-color);
   hyphens: auto;
   line-height: var(--doc-line-height);
-  padding: 0 1rem;
-  margin-top: 2.5rem;
+}
+
+.swagger .main-content-inner--read-mode {
+  max-width: 1800px;
+  margin: 0 auto;
 }
 
 .swagger a,
@@ -225,3 +228,185 @@
 .swagger .valign-middle {
   vertical-align: middle;
 }
+
+/* Dan's edits */
+.rapidoc-container {
+  height: 100%;
+  width: 100%;
+  display: block;
+  padding-top: 0.5rem;
+  padding-top: var(--navbar-height);
+}
+
+.swagger .nav-bar {
+  border-right: 1px solid var(--nav-border-color);
+  width: var(--nav-width);
+  padding-top: 0.5rem;
+}
+
+.swagger .title,
+.swagger #api-title,
+.swagger h1,
+.swagger h2,
+.swagger h3,
+.swagger h4 {
+  font-weight: bold !important;
+  font-family: var(--heading-font-family);
+  text-transform: capitalize !important;
+}
+
+.req-res-title::first-line {
+  font-weight: bold !important;
+  font-family: var(--heading-font-family);
+  text-transform: capitalize !important;
+  color: red;
+}
+
+.swagger .nav-scroll {
+  padding-left: 1rem;
+  padding-right: 0.5rem;
+  padding-bottom: 2rem;
+}
+
+::part(section-overview-title) {
+  padding-top: 3rem;
+}
+
+::part(section-servers) > h2,
+::part(section-auth) > h2 {
+  padding-top: 5rem !important;
+}
+
+::part(section-tag) {
+  border-color: var(--nav-border-color);
+  padding-top: 4rem;
+}
+
+::part(section-operation) {
+  margin-top: 3rem;
+}
+
+::part(section-operation-summary) {
+  padding-top: 2rem;
+  margin-bottom: 0;
+  scroll-margin-top: 4rem !important;
+  scroll-padding-top: 4rem !important;
+}
+
+::part(operation-divider) {
+  display: none;
+}
+
+::part(section-operations-in-tag) {
+  padding-top: 1rem;
+}
+
+::part(section-operation-webhook-method) {
+  background: var(--pre-background);
+  padding: 0.5rem 1rem;
+  width: fit-content;
+  border-radius: 5px;
+  margin: 0.25rem 0 0.75rem;
+}
+
+.expanded-req-resp-container .response-panel {
+  border: 0 !important;
+}
+
+.swagger .left-bar.active {
+  border-color: transparent !important;
+  background: var(--nav-hover-bg-color) !important;
+}
+
+.swagger .nav-bar-section {
+  text-align: left !important;
+  background: transparent !important;
+  cursor: default;
+  margin-top: 1.5rem;
+  padding-left: 1rem;
+  padding-bottom: 0;
+  font-size: 0.7rem;
+}
+
+.swagger .nav-bar-section:hover {
+  cursor: default;
+  background-color: transparent;
+  color: default !important;
+}
+
+.swagger .nav-bar-section-title {
+  padding-left: 0.25rem;
+}
+
+.swagger .nav-bar-section > div:first-child {
+  display: none !important;
+}
+
+.swagger .nav-bar-paths-under-tag {
+  padding-left: 0.75rem;
+}
+
+.swagger .nav-bar-info,
+::part(section-navbar-item) {
+  padding: 0.5rem;
+}
+
+.m-table .param-name {
+  text-align: left;
+}
+
+.m-table .param-type {
+  text-align: left;
+}
+
+/*
+Shadow Root CSS
+- this works by using the tags exposed in exportparts under the custom HTML elements in the DOM.
+- more info on how to use here:
+-- https: //developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/exportparts
+--https: //jordanbrennan.hashnode.dev/8-ways-to-style-the-shadow-dom
+- the format exposed is "internal:external" where you can use "external" to target in this CSS sheet
+- unfortunately not everything is exposed, so you cannot target general classes
+
+// API Request parts = <api-request>
+wrap-request-btn:wrap-request-btn,
+btn:btn,
+btn-fill:btn-fill,
+btn-outline:btn-outline,
+btn-try:btn-try,
+btn-clear:btn-clear,
+btn-clear-resp:btn-clear-resp,
+file-input:file-input,
+textbox:textbox,
+textbox-param:textbox-param,
+textarea:textarea,
+textarea-param:textarea-param,
+anchor:anchor,
+anchor-param-example:anchor-param-example,
+schema-description:schema-description,
+schema-multiline-toggle:schema-multiline-toggle
+
+// API Response parts = <api-response>
+btn:btn,
+btn-response-status:btn-response-status,
+btn-selected-response-status:btn-selected-response-status,
+btn-fill:btn-fill,
+btn-copy:btn-copy,
+schema-description:schema-description,
+schema-multiline-toggle:schema-multiline-toggle
+
+// JSON tree parts = <json-tree>
+btn:btn,
+btn-fill:btn-fill,
+btn-copy:btn-copy
+*/
+
+/* Outer container for API elements */
+.expanded-req-resp-container {
+  margin-top: 2rem;
+  display: grid;
+  grid-template-columns: 1fr; /* change this to 1fr 1fr for 2 columns */
+  gap: 1rem;
+}
+
+/* End Dan's edits */

--- a/src/css/toolbar.css
+++ b/src/css/toolbar.css
@@ -9,6 +9,7 @@
   position: sticky;
   top: var(--navbar-height);
   z-index: var(--z-index-toolbar);
+  border-bottom: 1px solid var(--nav-border-color);
 }
 
 .toolbar a {

--- a/src/layouts/swagger.hbs
+++ b/src/layouts/swagger.hbs
@@ -7,180 +7,181 @@
     {{> header-scripts}}
     <style>
       td.tableblock>.content>: first-child {
-        margin-top:0;
+        margin-top: 0;
       }
     </style>
   </head>
-  <body class="body swagger" style="padding-top:0; height:100vh;">
-    <rapi-doc id="api" spec-url="{{resolve-resource page.attributes.api-spec-url}}" primary-color="#e2401b"
-        show-header=false {{#if page.attributes.try-it}}allow-try=true {{else}} allow-try=false {{/if}} show-curl-before-try=true show-method-in-nav-bar="as-colored-text" show-info="true" render-style="read" regular-font="'Calibre Regular', 'Open Sans', arial, helvetica, sans-serif" fill-request-fields-with-example="true" nav-bg-color="#fff"  bg-color="#fff" nav-item-spacing="relaxed" font-size="largest" css-file="{{{uiRootPath}}}/css/site.css"  css-classes="swagger">
-    <div class="toolbar" role="navigation" style="top:-5px;">
-      {{#with site.homeUrl}}
-      {{#if (ne @root.page.component.name 'redpanda-labs')}}
-      <a href="{{{relativize this}}}" aria-label="Go to home page" class="home-link{{#if @root.page.home}} is-current{{/if}}"></a>
-      {{/if}}
-      {{/with}}
-    {{> breadcrumbs}}
-    {{#if (is-cloud-url page.url)}}
-      {{> cloud-api-feedback}}
-    {{/if}}
-    <div class="col">
-    <div class="theme-switcher">
-      <button id="switch-theme" type="button" title="Switch between dark and light mode" aria-label="Switch between dark and light mode" aria-live="polite">
-        <img class="theme-image" src="{{{uiRootPath}}}/img/octicons-24.svg#view-sun" alt=""></img>
-      </button>
+  <body style="padding-top:0; height:100vh;">
+{{> header}}
+
+    <div class="rapidoc-container">
+      <rapi-doc 
+        id="api" 
+        spec-url="{{resolve-resource page.attributes.api-spec-url}}" 
+        {{!-- spec-url="https://docs.redpanda.com/api/_attachments/cloud-api.yaml" --}}
+        primary-color="#e2401b"
+        show-header=false 
+        {{#if page.attributes.try-it}} allow-try=true {{else}} allow-try=false {{/if}} 
+        show-curl-before-try=true 
+        show-method-in-nav-bar="false" 
+        show-info="true" 
+        render-style="read" 
+        regular-font="'Calibre Regular', 'Open Sans', arial, helvetica, sans-serif" 
+        fill-request-fields-with-example="true" 
+        nav-bg-color="#fff"  
+        bg-color="#fff" 
+        nav-item-spacing="relaxed" 
+        font-size="largest" 
+        fetch-credentials="include" 
+        css-file="{{{uiRootPath}}}/css/site.css"  
+        css-classes="swagger">
+
+        <div class="toolbar" role="navigation" style="top: 0;">
+          {{#with site.homeUrl}}
+          {{#if (ne @root.page.component.name 'redpanda-labs')}}
+          <a href="{{{relativize this}}}" aria-label="Go to home page" class="home-link{{#if @root.page.home}} is-current{{/if}}"></a>
+          {{/if}}
+          {{/with}}
+          {{> breadcrumbs}}
+          {{#if (is-cloud-url page.url)}}
+          {{> cloud-api-feedback}}
+          {{/if}}
+        </div>
+        {{#each (get-api-slots page.url)}}
+          {{{this}}}
+        {{/each}}
+
+        {{> tracking-pixel}}
+      </rapi-doc>
     </div>
-  </div>
-    </div>
-    <div slot="nav-logo" style="display: flex; align-items: center; justify-content: center;">
-      <a class="navbar-item" href="{{{or site.url siteRootPath}}}" aria-label="Go to home page"><img src="{{{uiRootPath}}}/img/redpanda-docs-logo.svg" width="250px" height= "30px" alt="Redpanda logo"/></a>
-    </div>
-    {{#each (get-api-slots page.url)}}
-        {{{this}}}
-    {{/each}}
-    <div slot="footer">
-      {{> footer}}
-    </div>
-    {{> tracking-pixel}}
-    </rapi-doc>
-    <script defer>
-      function getNavbarHeight() {
-          const navbar = document.querySelector('.toolbar');
-          if (!navbar) {
-            console.error('Toolbar not found.');
-            return null;
-          }
-          const style = window.getComputedStyle(navbar);
-          const height = parseFloat(style.height);
-          return height;
-      }
 
-      window.addEventListener('DOMContentLoaded', function() {
-        const height = getNavbarHeight();
-        const rapidoc = document.querySelector('rapi-doc#api');
-        if (rapidoc && rapidoc.shadowRoot) {
-          // Hide the client ID
-          const observer1 = new MutationObserver(function(mutationsList, observer) {
-            mutationsList.forEach(mutation => {
-              mutation.addedNodes.forEach(node => {
-                if (node.nodeType === Node.ELEMENT_NODE) {
-                  const targetElement = node.querySelector('.oauth2.implicit.auth0.oauth-client-id');
-                  if (targetElement) {
-                    targetElement.style.display = 'none';
-                  }
-                  const subTitleDivs = node.querySelectorAll('.sub-title');
-                  subTitleDivs.forEach(div => {
-                    const h2 = document.createElement('h2');
-                    h2.innerHTML = div.innerHTML;
-                    const partAttribute = div.getAttribute('part');
-                    if (partAttribute) {
-                      h2.setAttribute('part', partAttribute);
-                    }
-                    div.parentNode.replaceChild(h2, div);
-                  });
-                  const headingElements = Array.from(node.querySelectorAll('h2:not(div.sect > h2), h3:not(div.sect > h3), h4:not(div.sect > h4)'));
-                  headingElements.forEach(heading => {
-                    if (!heading.closest('.sect')) {
-                      heading.style.fontSize = 'revert';
-                      heading.style.paddingTop = 'revert';
-                      heading.style.marginBlockEnd = 'revert';
-                    }
-                  });
-                  const tables = rapidoc.shadowRoot.querySelectorAll('table');
-                  // Filter tables to include only those that contain 'Region' in their innerHTML
-                  const filteredTables = Array.from(tables).filter(table => table.innerHTML.includes('Region'));
-                  if (filteredTables.length > 0) {
-                    processTables(filteredTables);
-                    observer1.disconnect()
-                  }
-                }
-              });
-            });
-          });
-          observer1.observe(rapidoc.shadowRoot, { childList: true, subtree: true });
-          rapidoc.style.marginTop = height + 'px'; // Adjusts the top margin based on the navbar's height
-          rapidoc.addEventListener('before-try', (e) => {
-            const message = "Warning: API calls are executed against a real environment, not a sandbox.\nAre you sure you want to send this Delete request?"
-            if (e.detail.request.method === 'DELETE') {
-              if (!confirm(message)) {
-                e.detail.controller.abort();
-              }
-            }
-          });
-        }
-      });
-
-      let resizeTimeout;
-      function debouncedApplyMobileLogic() {
-          clearTimeout(resizeTimeout);
-          resizeTimeout = setTimeout(applyMobileLogic, 250);
-      }
-
-      function applyMobileLogic() {
-          const rapidocEl = document.getElementById('api');
-          if (window.innerWidth <= 768) {
-            rapidocEl.setAttribute('render-style', 'view');
-          } else {
-            rapidocEl.setAttribute('render-style', 'read');
-          }
-      }
-
-      window.addEventListener('DOMContentLoaded', applyMobileLogic);
-      window.addEventListener('resize', debouncedApplyMobileLogic);
-      function createTable(data, originalTable) {
-        // Create a new table element
-        const newTable = document.createElement('table');
-        newTable.style.width = '100%';
-        newTable.className = 'tableblock stripes-even';
-        newTable.innerHTML = '<thead><tr><th>Region</th><th>Zones</th><th>Throughput Tiers</th></tr></thead>';
-
-        const tbody = document.createElement('tbody');
-
-        // Loop through each region to create rows
-        data.regions.forEach(region => {
-          const row = document.createElement('tr');
-          row.innerHTML = `<td class="tableblock halign-left valign-top"><div class="content">${region.region}</div></td>
-                          <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist" style="margin-top:0;"><ul style="margin-top:0;">${region.zones.map(zone => `<li>${zone}</li>`).join('')}</ul></div></div></td>
-                          <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist" style="margin-top:0;"><ul style="margin-top:0;">${region.tiers.map(tier => `<li>${tier}</li>`).join('')}</ul></div></div></td>`;
-          tbody.appendChild(row);
-        });
-
-        newTable.appendChild(tbody);
-        // Replace the original table with the new table
-        originalTable.parentNode.replaceChild(newTable, originalTable);
-      }
-
-      function processTables(tables) {
-        tables.forEach((table, index) => {
-          if (table.classList.contains('tableblock')) return
-          if (!table.innerHTML.includes('Region')) return
-          const platform = index === 0 ? 'Google Cloud Platform (GCP)' : 'Amazon Web Services (AWS)';
-          const rows = table.querySelectorAll('tr');
-          let regions = [];
-
-          rows.forEach((row, rowIndex) => {
-            if (rowIndex > 0) { // Skip header row
-              const cells = row.querySelectorAll('td');
-              const region = cells[0].textContent.trim();
-              const zones = cells[1].textContent.split(',').map(zone => zone.trim());
-              const tiers = cells[2].innerHTML.split('<br>').filter(tier => tier.trim() !== '');
-
-              regions.push({
-                region,
-                zones,
-                tiers
-              });
-            }
-          });
-
-          const regionsData = {
-            platform,
-            regions
-          };
-          createTable(regionsData, table);
-        });
-      }
-    </script>
     {{> cloud-api-feedback-modal}}
   </body>
+  
+  <script defer>
+    window.addEventListener('DOMContentLoaded', function () {
+      const rapidoc = document.querySelector('rapi-doc#api');
+      if (rapidoc && rapidoc.shadowRoot) {
+        // Hide the client ID
+        const observer1 = new MutationObserver(function (mutationsList, observer) {
+          mutationsList.forEach(mutation => {
+            mutation.addedNodes.forEach(node => {
+              if (node.nodeType === Node.ELEMENT_NODE) {
+                const targetElement = node.querySelector('.oauth2.implicit.auth0.oauth-client-id');
+                if (targetElement) {
+                  targetElement.style.display = 'none';
+                }
+                const subTitleDivs = node.querySelectorAll('.sub-title');
+                subTitleDivs.forEach(div => {
+                  const h2 = document.createElement('h2');
+                  h2.innerHTML = div.innerHTML;
+                  const partAttribute = div.getAttribute('part');
+                  if (partAttribute) {
+                    h2.setAttribute('part', partAttribute);
+                  }
+                  div.parentNode.replaceChild(h2, div);
+                });
+                const headingElements = Array.from(node.querySelectorAll('h2:not(div.sect > h2), h3:not(div.sect > h3), h4:not(div.sect > h4)'));
+                headingElements.forEach(heading => {
+                  if (!heading.closest('.sect')) {
+                    heading.style.fontSize = 'revert';
+                    heading.style.paddingTop = 'revert';
+                    heading.style.marginBlockEnd = 'revert';
+                  }
+                });
+                const tables = rapidoc.shadowRoot.querySelectorAll('table');
+                // Filter tables to include only those that contain 'Region' in their innerHTML
+                const filteredTables = Array.from(tables).filter(table => table.innerHTML.includes('Region'));
+                if (filteredTables.length > 0) {
+                  processTables(filteredTables);
+                  observer1.disconnect()
+                }
+              }
+            });
+          });
+        });
+        observer1.observe(rapidoc.shadowRoot, { childList: true, subtree: true });
+        rapidoc.addEventListener('before-try', (e) => {
+          const message = "Warning: API calls are executed against a real environment, not a sandbox.\nAre you sure you want to send this Delete request?"
+          if (e.detail.request.method === 'DELETE') {
+            if (!confirm(message)) {
+              e.detail.controller.abort();
+            }
+          }
+        });
+      }
+    });
+
+    let resizeTimeout;
+    function debouncedApplyMobileLogic() {
+      clearTimeout(resizeTimeout);
+      resizeTimeout = setTimeout(applyMobileLogic, 250);
+    }
+
+    function applyMobileLogic() {
+      const rapidocEl = document.getElementById('api');
+      if (window.innerWidth <= 768) {
+        rapidocEl.setAttribute('render-style', 'view');
+      } else {
+        rapidocEl.setAttribute('render-style', 'read');
+      }
+    }
+
+    window.addEventListener('DOMContentLoaded', applyMobileLogic);
+    window.addEventListener('resize', debouncedApplyMobileLogic);
+
+    function createTable(data, originalTable) {
+      // Create a new table element
+      const newTable = document.createElement('table');
+      newTable.style.width = '100%';
+      newTable.className = 'tableblock stripes-even';
+      newTable.innerHTML = '<thead><tr><th>Region</th><th>Zones</th><th>Throughput Tiers</th></tr></thead>';
+
+      const tbody = document.createElement('tbody');
+
+      // Loop through each region to create rows
+      data.regions.forEach(region => {
+        const row = document.createElement('tr');
+        row.innerHTML = `<td class="tableblock halign-left valign-top"><div class="content">${region.region}</div></td>
+                            <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist" style="margin-top:0;"><ul style="margin-top:0;">${region.zones.map(zone => `<li>${zone}</li>`).join('')}</ul></div></div></td>
+                            <td class="tableblock halign-left valign-top"><div class="content"><div class="ulist" style="margin-top:0;"><ul style="margin-top:0;">${region.tiers.map(tier => `<li>${tier}</li>`).join('')}</ul></div></div></td>`;
+        tbody.appendChild(row);
+      });
+
+      newTable.appendChild(tbody);
+      // Replace the original table with the new table
+      originalTable.parentNode.replaceChild(newTable, originalTable);
+    }
+
+    function processTables(tables) {
+      tables.forEach((table, index) => {
+        if (table.classList.contains('tableblock')) return
+        if (!table.innerHTML.includes('Region')) return
+        const platform = index === 0 ? 'Google Cloud Platform (GCP)' : 'Amazon Web Services (AWS)';
+        const rows = table.querySelectorAll('tr');
+        let regions = [];
+
+        rows.forEach((row, rowIndex) => {
+          if (rowIndex > 0) { // Skip header row
+            const cells = row.querySelectorAll('td');
+            const region = cells[0].textContent.trim();
+            const zones = cells[1].textContent.split(',').map(zone => zone.trim());
+            const tiers = cells[2].innerHTML.split('<br>').filter(tier => tier.trim() !== '');
+
+            regions.push({
+              region,
+              zones,
+              tiers
+            });
+          }
+        });
+
+        const regionsData = {
+          platform,
+          regions
+        };
+        createTable(regionsData, table);
+      });
+    }
+  </script>
 </html>


### PR DESCRIPTION
## Context
There are some bottlenecks with Rapidoc and developing themes due to the shadow DOM, i've added some comments in the swagger.css file to make it slightly easier to edit these, but not everything we want visually can be achieved with Rapidoc.

I've cleaned up a lot of styles that were causing issues, including some small tweaks with the main docs theme.

This isn't a magic bullet, but should hopefully make the API docs closer in look/feel to the main docs.  We should revisit how the themes work at a later date.

## Fixes
- cleanup rapiddoc styles
- cleanup darkmode styles
- cleanup toolbar/breadcrumb position + style

## Guide
To test the rapiddoc styles locally you need to make two edits locally, and don't commit them.
1. In `swagger.hbs` add `spec-url="https://docs.redpanda.com/api/_attachments/cloud-api.yaml"` to the rapi-doc element.
2. in `index.adoc` add `:page-layout: swagger` to the meta at the top of the document

<img width="453" alt="image" src="https://github.com/redpanda-data/docs-ui/assets/523614/caf4dbd6-1383-45de-89fe-b8db83774047">

<img width="666" alt="image" src="https://github.com/redpanda-data/docs-ui/assets/523614/e672e0eb-0eed-40a1-b6ea-667e8c40434f">


## Before
<img width="1512" alt="Screenshot 2024-05-29 at 11 31 27" src="https://github.com/redpanda-data/docs-ui/assets/523614/47346748-0db6-481c-b8ee-e5271e5917c3">

## After
<img width="1512" alt="Screenshot 2024-05-29 at 11 31 51" src="https://github.com/redpanda-data/docs-ui/assets/523614/d76f3164-e7df-457b-ae18-8d58946ebdec">
