### PR TITLE
Support other components in index pages

### DIFF
--- a/src/helpers/get-page-info.js
+++ b/src/helpers/get-page-info.js
@@ -1,9 +1,20 @@
 'use strict'
 
-module.exports = (url, { data: { root } }) => {
-  const { contentCatalog, page } = root
+/**
+ * Retrieves page information based on the provided URL and component.
+ * If no component is provided, it searches all components for the page.
+ * @param {string} url - The URL of the page.
+ * @param {string} component - The component name.
+ * @param {object} context - The context object containing the content catalog.
+ * @param {object} context.data - The data object from the context.
+ * @param {object} context.data.root - The root object containing the content catalog.
+ * @returns {object} - An object containing page information.
+ */
+
+module.exports = (url, component, { data: { root } }) => {
+  const { contentCatalog } = root
   if (!contentCatalog) return
-  const pages = contentCatalog.findBy({ component: page.component.name, family: 'page' })
+  const pages = component ? contentCatalog.findBy({ component, family: 'page' }) : contentCatalog.findBy({ family: 'page' })
   for (let i = 0; i < pages.length; i++) {
     if (!url || pages[i].pub.url === url) {
       return {

--- a/src/partials/contributors-modal.hbs
+++ b/src/partials/contributors-modal.hbs
@@ -19,7 +19,7 @@
           </a>
         {{/if}}
         <p>Or, let us know about something that you want us to change:</p>
-        {{#with (get-page-info page.url)}}
+        {{#with (get-page-info page.url page.component.name)}}
         <a href="{{this.webUrl}}/issues/new?title=Docs: Feedback for {{{this.title}}}&template=01_doc_request.yml&link=[{{this.title}}]({{@root.site.url}}{{this.url}}) [Page source]({{this.editUrl}})" target="_blank" rel="noopener noreferrer"><span>Open an issue</span></a>
         {{/with}}
       </div>

--- a/src/partials/index.hbs
+++ b/src/partials/index.hbs
@@ -4,7 +4,7 @@
     {{#if (and (eq this.url @root.page.url) (ne this.items.length 0))}}
       {{#each this.items}}
         {{#if this.url}}
-          {{#with (get-page-info this.url)}}
+          {{#with (get-page-info this.url null)}}
             <li class="index"><a href="{{{relativize this.url}}}">{{{this.title}}}</a>
             {{#if (ne this.title this.description)}}
             <p class="index">{{{this.description}}}</p>
@@ -15,7 +15,7 @@
           <li class="index">{{{this.content}}}</li>
           <ul>
             {{#each this.items}}
-              {{#with (get-page-info this.url)}}
+              {{#with (get-page-info this.url null)}}
                 <li class="index"><a href="{{{relativize this.url}}}">{{{this.title}}}</a>
                 {{#if (ne this.title this.description)}}
                 <p class="index">{{{this.description}}}</p>

--- a/src/partials/nav-tree-lab.hbs
+++ b/src/partials/nav-tree-lab.hbs
@@ -43,7 +43,7 @@
       {{/with}}
       <li class="nav-item" data-depth="1">
         <div class="item">
-          {{#with (get-page-info page.url)}}
+          {{#with (get-page-info page.url page.component.name)}}
           <a class="nav-link" href="{{this.webUrl}}/tree/{{this.branch}}/{{this.path}}">Source Code<img class="dark-mode-filter" src="{{{@root.uiRootPath}}}/img/github.svg" width="30px" height= "20px" alt="GitHub logo" style="margin-bottom:-3px;"/></a>
           {{/with}}
         </div>


### PR DESCRIPTION
Allows writers to add links to other product docs in the nav tree and for those pages to be included in index pages.

Previously index pages only supported links to pages in the same Antora component.