### PR TITLE
Stop nav tree from disappearing at the bottom of pages

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -14,6 +14,7 @@
     width: calc(100% - var(--nav-width));
     padding-top: 0;
     min-width: 0; /* min-width: 0 required for flexbox to constrain overflowing elements */
+    min-height: 100vh;
   }
 
   main.index {


### PR DESCRIPTION
When tabs are clicked at the bottom of pages, it forces the main content to expand, which scrolls down the nav tree and hides the search. This change sets a minimum height to stop that from happening.
![2024-06-10_14-59-40 (1)](https://github.com/redpanda-data/docs-ui/assets/45230295/a3b722a3-1d40-4bc4-b03e-a3950d5fbc5b)

