### PR TITLE
Allow for pages in docs to list related labs

### DIFF
--- a/src/helpers/list-related-labs.js
+++ b/src/helpers/list-related-labs.js
@@ -1,0 +1,23 @@
+'use strict'
+
+module.exports = (title, attributes, content, { data: { root } }) => {
+  const { contentCatalog } = root
+  if (attributes['component-name'] === 'redpanda-labs') return content
+  if (!contentCatalog) return content
+
+  // Extract related labs from attributes
+  const relatedLabs = attributes['related-labs'] ? JSON.parse(attributes['related-labs']) : []
+  if (!relatedLabs.length) return content
+
+  // Append "Suggested labs" heading if there are matching labs
+  let contentString = content.toString('utf8')
+  contentString += '<div class="ulist">\n<ul>'
+
+  relatedLabs.forEach((lab, index) => {
+    contentString += `<li><a href="${lab.url}">${lab.title}</a>: ${lab.description}</li>`
+  })
+  contentString += '</ul></div>'.trim()
+
+  const modifiedContent = Buffer.from(contentString, 'utf8')
+  return modifiedContent
+}

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -15,6 +15,10 @@
   {{> home}}
 {{else if (eq page.layout 'index')}}
   {{> index}}
+{{else if (eq page.attributes.role 'related-labs')}}
+  {{#with (list-related-labs page.title page.attributes page.contents)  as |listLabs|}}
+    {{{listLabs}}}
+  {{/with}}
 {{else}}
   {{> context-switcher}}
   {{#with (add-suggested-labs page.attributes page.contents)  as |suggestedLabs|}}


### PR DESCRIPTION
Required change: https://github.com/redpanda-data/docs-extensions-and-macros/pull/56

When a page includes the `:page-role: related-labs` attribute and a list of `:page-categories:` that match the categories in one or more labs, the template injects a list of related labs into the page:

![2024-06-25_12-43-14](https://github.com/redpanda-data/docs-ui/assets/45230295/d8aee67c-a98e-4ad7-8c6d-b9a0c64a6916)
