### PR TITLE
Modify scrollbar width

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -126,7 +126,7 @@ object[type="image/svg+xml"]:not([width]) {
     }
 
     body * {
-      scrollbar-width: thin;
+      scrollbar-width: none;
       scrollbar-color: var(--scrollbar-thumb-color) transparent;
     }
   }


### PR DESCRIPTION
On Windows machines running chrome, this CSS option can lead to an small padding arrow for the redesign 
![image](https://github.com/user-attachments/assets/219581a6-128c-4950-b14d-e48da50e76ce)

This change modifies this behavior and removes the scrollbar, making the arrow go away and adjusting the padding. Here's a GIF comparison
![Animation123](https://github.com/user-attachments/assets/8d0de26c-d592-4f68-a9cf-9267c97b0aa0)
