### PR TITLE
Support more Rapidoc slots

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -445,61 +445,61 @@ html {
   vertical-align: middle;
 }
 
-.doc .admonitionblock {
+.admonitionblock {
   position: relative;
   margin: 1.4rem 0 0;
   box-shadow: var(--admonition-border-box-shadow);
   padding: var(--admonition-padding);
 }
 
-.doc .admonitionblock.note {
+.admonitionblock.note {
   background-color: var(--note-background);
   border-left-width: var(--admonition-border-left-width);
   border-radius: var(--admonition-border-radius);
 }
 
-.doc .admonitionblock.warning {
+.admonitionblock.warning {
   background-color: var(--warning-background);
   border-left-width: var(--admonition-border-left-width);
   border-radius: var(--admonition-border-radius);
 }
 
-.doc .admonitionblock.tip {
+.admonitionblock.tip {
   background-color: var(--tip-background);
   border-left-width: var(--admonition-border-left-width);
   border-radius: var(--admonition-border-radius);
 }
 
-.doc .admonitionblock.caution {
+.admonitionblock.caution {
   background-color: var(--caution-background);
   border-left-width: var(--admonition-border-left-width);
   border-radius: var(--admonition-border-radius);
 }
 
-.doc .admonitionblock.important {
+.admonitionblock.important {
   background-color: var(--important-background);
   border-left-width: var(--admonition-border-left-width);
   border-radius: var(--admonition-border-radius);
 }
 
-.doc .admonitionblock td.content > :not(.title):first-child,
-.doc .admonitionblock td.content > .title + * {
+.admonitionblock td.content > :not(.title):first-child,
+.admonitionblock td.content > .title + * {
   margin-top: 0;
 }
 
-.doc .admonitionblock pre {
+.admonitionblock pre {
   font-size: calc(17 / var(--rem-base) * 1rem);
 }
 
 /* Note - dan - for some bizarre reason tables are used to structure notices, we have to turn all these table elements into block elements to get them to style correctly */
 /* I had to change this back to a fixed table layout to avoid the code blocks from escaping the admonition */
-.doc .admonitionblock > table {
+.admonitionblock > table {
   table-layout: fixed;
   position: relative;
   width: 100%;
 }
 
-.doc .admonitionblock td.content {
+.admonitionblock td.content {
   display: block;
   width: 100%;
   word-wrap: anywhere;
@@ -507,7 +507,7 @@ html {
   padding-left: 1.8rem;
 }
 
-.doc .admonitionblock .icon {
+.admonitionblock .icon {
   display: block;
   font-size: calc(18 / var(--rem-base) * 1rem);
   height: 1.25rem;
@@ -515,15 +515,15 @@ html {
   font-weight: var(--admonition-label-font-weight);
 }
 
-.doc .admonitionblock.caution .icon {
+.admonitionblock.caution .icon {
   color: var(--caution-on-color);
 }
 
-.doc .admonitionblock.important .icon {
+.admonitionblock.important .icon {
   color: var(--important-on-color);
 }
 
-.doc .admonitionblock.note .icon {
+.admonitionblock.note .icon {
   color: var(--note-on-color);
 }
 
@@ -567,14 +567,14 @@ html {
   height: 1.4em;
 }
 
-.doc .admonitionblock .icon i {
+.admonitionblock .icon i {
   display: inline-flex;
   align-items: center;
   height: 100%;
   font: unset;
 }
 
-.doc .admonitionblock .icon i::after {
+.admonitionblock .icon i::after {
   content: attr(title);
 }
 
@@ -797,11 +797,11 @@ table code {
 
 .doc .ulist .listingblock,
 .doc .olist .listingblock,
-.doc .admonitionblock .listingblock {
+.admonitionblock .listingblock {
   padding: 0;
 }
 
-.doc .admonitionblock .title {
+.admonitionblock .title {
   font-weight: bold;
 }
 
@@ -831,7 +831,7 @@ table code {
 }
 
 /* immediate sibling of an element with the class title, where this title class element is a direct child of a td element with the class content */
-.doc .admonitionblock td.content > .title + * {
+.admonitionblock td.content > .title + * {
   margin-top: 20px;
 }
 

--- a/src/css/header.css
+++ b/src/css/header.css
@@ -151,7 +151,11 @@ html.is-clipped--navbar {
 }
 
 .home .navbar-item,
-.home .navbar-link {
+.home .navbar-link,
+.api .navbar-item,
+.api .navbar-link,
+.status-404 .navbar-item,
+.status-404 .navbar-link {
   color: #f5f5f5;
 }
 

--- a/src/helpers/get-api-slots.js
+++ b/src/helpers/get-api-slots.js
@@ -40,9 +40,10 @@ module.exports = (url, { data }) => {
 }
 
 function wrapHtmlWithSlot (htmlContent, slotName) {
-  // Check if the slotName is 'auth' or 'overview'
-  if (slotName === 'auth' || slotName === 'overview') {
-    return `<div slot="${slotName}">${htmlContent}</div>`
+  if (slotName) {
+    // Replace all instances of '9' with '/'
+    const modifiedSlotName = slotName.replace(/9/g, '/')
+    return `<div slot="${modifiedSlotName}">${htmlContent}</div>`
   }
   // Return the content without wrapping if the slot does not match
   return htmlContent

--- a/src/helpers/get-api-slots.js
+++ b/src/helpers/get-api-slots.js
@@ -41,8 +41,8 @@ module.exports = (url, { data }) => {
 
 function wrapHtmlWithSlot (htmlContent, slotName) {
   if (slotName) {
-    // Replace all instances of '9' with '/'
-    const modifiedSlotName = slotName.replace(/9/g, '/')
+    // Replace all instances of '&#47;' with '/'
+    const modifiedSlotName = slotName.replace(/&#47;/g, '/')
     return `<div slot="${modifiedSlotName}">${htmlContent}</div>`
   }
   // Return the content without wrapping if the slot does not match

--- a/src/layouts/swagger.hbs
+++ b/src/layouts/swagger.hbs
@@ -11,7 +11,7 @@
       }
     </style>
   </head>
-  <body style="padding-top:0; height:100vh;">
+  <body style="padding-top:0; height:100vh;" class="api">
 {{> header}}
 
     <div class="rapidoc-container swagger">

--- a/src/partials/breadcrumbs.hbs
+++ b/src/partials/breadcrumbs.hbs
@@ -3,9 +3,11 @@
     {{#with site.homeUrl}}
     <li><a href="{{{relativize this}}}" aria-label="Go to home page">Docs</a></li>
     {{/with}}
+    {{#if (ne page.component.name 'api')}}
     <li>
       <a href="{{{relativize page.component.url}}}">{{{page.component.title}}}</a>
     </li>
+    {{/if}}
     {{#if page.breadcrumbs}}
       {{#each page.breadcrumbs}}
         {{#if (ne (relativize ./url) (relativize @root.page.component.url))}}


### PR DESCRIPTION
Adds support for all [Rapidoc slots](https://rapidocweb.com/api.html#slots).

In order to support the `{method}-{path}` slot, we must replace `/` in the path with `&#47;` so that the file system doesn't interpret `/` as a directory. The UI replaces `&#47;` with `/` before injecting the slot.

Required for https://github.com/redpanda-data/docs/pull/194
