### PR TITLE
Use 9 as the API slot placeholder

### DIFF
--- a/src/helpers/get-api-slots.js
+++ b/src/helpers/get-api-slots.js
@@ -41,8 +41,8 @@ module.exports = (url, { data }) => {
 
 function wrapHtmlWithSlot (htmlContent, slotName) {
   if (slotName) {
-    // Replace all instances of '&#47;' with '/'
-    const modifiedSlotName = slotName.replace(/&#47;/g, '/')
+    // Replace all instances of '9' with '/'
+    const modifiedSlotName = slotName.replace(/9/g, '/')
     return `<div slot="${modifiedSlotName}">${htmlContent}</div>`
   }
   // Return the content without wrapping if the slot does not match


### PR DESCRIPTION
Netlify does not allow us to deploy files with `#` in the name.

```
Error message
3:48:53 PM:   Deploy did not succeed: Invalid filename 'api/admin/post-&#47;partitions&#47;force_recover_from_nodes/force_recover_from_nodes/index.html'. Deployed filenames cannot contain # or ?
```