### PR TITLE
Fix scrolling bug

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -8,15 +8,10 @@ html {
   box-sizing: border-box;
   font-size: var(--body-font-size);
   height: 100%;
-  scroll-behavior: smooth;
   max-width: 100%;
   overflow-x: hidden;
   padding: 0;
   margin: 0;
-}
-
-html.no-smooth-scroll {
-  scroll-behavior: unset;
 }
 
 @media screen and (min-width: 1024px) {


### PR DESCRIPTION
When clicking an anchor in the table of contents in dark mode on mobile, the content would sometimes disappear while scrolling. This was reported by Alex in Slack and reproduced by the docs team: https://redpandadata.slack.com/archives/C01LK3UK2K1/p1722698887293389

Thanks to @yougotashovel for the debugging tips: The issue was traced back to the use of `scroll-behavior: smooth` applied to the `html` element. While smooth scrolling provides a visually appealing transition, it caused an unintended side effect on mobile devices in dark mode. Specifically, the content would sometimes disappear during the scrolling animation, likely due to a rendering issue in certain mobile browsers.

Before:

https://github.com/user-attachments/assets/458a870b-4426-4621-83c1-d3b6b837c098


After:



https://github.com/user-attachments/assets/b15cc75e-75ed-4460-b8be-b0f8db3940be


