### PR TITLE
DOC-687 Keep external link icon with link text

### DIFF
--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -439,6 +439,12 @@ The fog comes
 on little cat feet.
 ____
 
+== External links
+
+External links include an icon like so: link:https://awscli.amazonaws.com/v2/documentation/api/latest/reference/sts/get-caller-identity.html[AWS CLI reference].
+
+The link should not wrap, keeping the icon and the link text together and avoiding a single period on one line.
+
 == Fin
 
 That's all, folks!

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -162,6 +162,7 @@ html {
   text-underline-offset: 2px;
   text-decoration-color: var(--color-aliases-static-palette-text-tertiary);
   color: var(--body-font-color);
+  white-space: nowrap;
 }
 
 .doc a:hover,


### PR DESCRIPTION
This pull request resolves the wrapping issue for external links by preventing line breaks between the link, icon, and immediately following punctuation.

The `white-space: nowrap;` CSS property is applied to links to ensure the link, icon, and any following punctuation appear as a single, non-wrapping unit.

[Preview](https://deploy-preview-226--docs-ui.netlify.app/#external-links)