### PR TITLE
Fix whitespace issues by targeting only links inside paragraphs that aren't in table cells

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -162,6 +162,9 @@ html {
   text-underline-offset: 2px;
   text-decoration-color: var(--color-aliases-static-palette-text-tertiary);
   color: var(--body-font-color);
+}
+
+.doc p:not(.tableblock) a {
   white-space: nowrap;
 }
 


### PR DESCRIPTION
We're seeing some side effect of #226 , this PR makes the whitespace change more specific to avoid affecting other elements.