### PR TITLE
Fix callouts

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -1562,6 +1562,8 @@ html[data-theme=dark] code[class*=language-] .token.function {
   height: 1.25em;
   letter-spacing: -0.25ex;
   text-indent: -0.25ex;
+  color: var(--body-font-color);
+  margin-left: 4px;
 }
 
 .doc .conum[data-value]::after {

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -74,6 +74,10 @@ html {
   .doc h1 {
     font-size: calc(44 / var(--rem-base) * 1rem);
   }
+
+  .doc p:not(.tableblock) a {
+    white-space: nowrap;
+  }
 }
 
 .doc > h2#name + .sectionbody {
@@ -162,10 +166,6 @@ html {
   text-underline-offset: 2px;
   text-decoration-color: var(--color-aliases-static-palette-text-tertiary);
   color: var(--body-font-color);
-}
-
-.doc p:not(.tableblock) a {
-  white-space: nowrap;
 }
 
 .doc a:hover,

--- a/src/js/11-editable-placeholders.js
+++ b/src/js/11-editable-placeholders.js
@@ -177,9 +177,13 @@ function unnestPlaceholders() {
     if (!element || !element.textContent) {
       return;
     }
-
-    const pattern = /(\s\(<span class="token number">(\d+)<\/span>\)|(\s)\((\d+)\))$/gm;
-    element.innerHTML = element.innerHTML.replace(pattern, (match, p1, p2, p3, p4) => {
+    // First regex: Handle standalone numbers in parentheses, avoiding function-like patterns
+    const standalonePattern = /(?<!\w)\((\d+)\)(?!\w)$/g;
+    element.innerHTML = element.innerHTML.replace(standalonePattern, (match, num) => {
+      return `<i class="conum" data-value="${num}"></i>`;
+    });
+    const complexPattern = /(\s\(<span class="token number">(\d+)<\/span>\)|(\s)\((\d+)\))$/gm;
+    element.innerHTML = element.innerHTML.replace(complexPattern, (match, p1, p2, p3, p4) => {
       return p3 ? `${p3}<i class="conum" data-value="${p4}"></i>` : `<i class="conum" data-value="${p2}"></i>`;
     });
   }

--- a/src/js/11-editable-placeholders.js
+++ b/src/js/11-editable-placeholders.js
@@ -177,7 +177,7 @@ function unnestPlaceholders() {
     if (!element || !element.textContent) {
       return;
     }
-    // First regex: Handle standalone numbers in parentheses, avoiding function-like patterns
+    // Handle standalone numbers in parentheses, avoiding function-like patterns
     const standalonePattern = /(?<!\w)\((\d+)\)(?!\w)$/g;
     element.innerHTML = element.innerHTML.replace(standalonePattern, (match, num) => {
       return `<i class="conum" data-value="${num}"></i>`;


### PR DESCRIPTION
Review deadline: 6 November

This PR enhances callout detection in code blocks to ensure more reliable handling of various formats. Previously, standalone conum numbers in parentheses could be incorrectly converted, including function arguments like convert(2) and HTML-wrapped spans. This update introduces two regular expressions to separately handle these cases and improve accuracy.

[Preview](https://deploy-preview-230--docs-ui.netlify.app/#some-code)