### PR TITLE
Handle non-JSON arguments

### DIFF
--- a/src/helpers/obj.js
+++ b/src/helpers/obj.js
@@ -4,6 +4,5 @@ module.exports = (a) => {
   if (typeof a === 'undefined' || a === null) {
     return {}
   }
-  
   return JSON.parse(a)
 }

--- a/src/helpers/obj.js
+++ b/src/helpers/obj.js
@@ -1,3 +1,9 @@
 'use strict'
 
-module.exports = (a) => JSON.parse(a)
+module.exports = (a) => {
+  if (typeof a === 'undefined' || a === null) {
+    return {}
+  }
+  
+  return JSON.parse(a)
+}


### PR DESCRIPTION
When this is unhandled, the error propagates to Antora and results in a failed build. For example:

```
FATAL (antora): Unexpected token u in JSON at position 0 in UI template partials/bloblang-playground.hbs
```

This handles the error gracefully and allows our templates to ignore empty objects