### PR TITLE
DOC-721 Add template for autogenerated index pages from filtered docs

### DIFF
--- a/src/helpers/get-index-data.js
+++ b/src/helpers/get-index-data.js
@@ -1,0 +1,17 @@
+
+module.exports = ({ data: { root } }) => {
+  const { page } = root
+  const indexKey = page.attributes['index-data']
+  if (!indexKey) return null
+  const indexData = page.component.asciidoc.attributes[indexKey]
+  if (!indexData) return null
+  try {
+    const parsedData = JSON.parse(indexData)
+    const currentPageUrl = page.url
+    const filteredData = parsedData.filter((item) => item.url !== currentPageUrl)
+    return filteredData
+  } catch (error) {
+    console.log(`Error parsing JSON attribute "${indexKey}" in ${page.url} component. Index page will be empty. Make sure the generate-index-data extension is correctly configured.\n\n ${error}`)
+    return null
+  }
+}

--- a/src/helpers/get-index-data.js
+++ b/src/helpers/get-index-data.js
@@ -1,17 +1,40 @@
-
 module.exports = ({ data: { root } }) => {
   const { page } = root
   const indexKey = page.attributes['index-data']
   if (!indexKey) return null
+
   const indexData = page.component.asciidoc.attributes[indexKey]
   if (!indexData) return null
+  const matchComponentVersion = page.attributes['match-component-version']
+
   try {
     const parsedData = JSON.parse(indexData)
     const currentPageUrl = page.url
-    const filteredData = parsedData.filter((item) => item.url !== currentPageUrl)
+    const currentComponent = page.component.name
+    const currentVersion = page.version
+
+    const filteredData = parsedData.reduce((acc, item) => {
+      if (item.pages && Array.isArray(item.pages)) {
+        const filteredPages = item.pages.filter((page) => {
+          const isNotCurrentPage = page.url !== currentPageUrl
+
+          // Optional filtering by component and version
+          const matchesComponentVersion = !matchComponentVersion || (
+            item.component === currentComponent && item.version === currentVersion
+          )
+
+          return isNotCurrentPage && matchesComponentVersion
+        })
+        acc.push(...filteredPages)
+      }
+      return acc
+    }, [])
+
     return filteredData
   } catch (error) {
-    console.log(`Error parsing JSON attribute "${indexKey}" in ${page.url} component. Index page will be empty. Make sure the generate-index-data extension is correctly configured.\n\n ${error}`)
+    console.log(
+      `Error parsing JSON attribute "${indexKey}" in ${page.url} component. Index page will be empty. Make sure the generate-index-data extension is correctly configured.\n\n ${error}`
+    )
     return null
   }
 }

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -36,6 +36,8 @@
   {{> component-home-v2}}
 {{else if (eq page.attributes.role 'bloblang-playground')}}
   {{> bloblang-playground}}
+{{else if (eq page.attributes.role 'index-list')}}
+  {{> index-list}}
 {{else if (eq page.layout 'index')}}
   {{> index}}
 {{else if (eq page.attributes.role 'related-labs')}}

--- a/src/partials/index-list.hbs
+++ b/src/partials/index-list.hbs
@@ -1,0 +1,18 @@
+{{{page.contents}}}
+
+{{#with (get-index-data) as |indexData|}}
+  {{#if indexData}}
+    <ul class="index">
+      {{#each indexData}}
+        <li class="index">
+          <a href="{{{relativize this.url}}}">{{{this.title}}}</a>
+          {{#if (ne this.title this.description)}}
+            <p class="index">{{{this.description}}}</p>
+          {{/if}}
+        </li>
+      {{/each}}
+    </ul>
+  {{else}}
+    <p>No index data found.</p>
+  {{/if}}
+{{/with}}


### PR DESCRIPTION
This PR introduces a new `get-index-data.js` helper and corresponding `index-list.hbs` UI template to support autogenerating index pages with links that aren't required to be in the same nav tree section (as we already have in the index.hbs` template). These additions aim to enhance the organization, navigability, and user experience of the Redpanda docs site by enabling dynamic, categorized lists of documentation pages based on configurable criteria.

These index pages:

- Enable users to browse through categorized lists of documentation pages, enhancing their ability to find relevant information quickly.

- Ensure that indexes remain up-to-date as new pages are added or existing ones are modified.

- Provide a standardized layout and styling for all index pages, ensuring a cohesive look and feel across the docs site.

Here's an example of how this template will be used:

```asciidoc
= Docker Compose Labs
:page-index-data: docker-labs-index
:page-role: index-list
```

- `page-index-data` refers to the name of the attribute that contains the data required to render the list on the page (an extension will handle this: https://github.com/redpanda-data/docs-extensions-and-macros/pull/87).
- `page-role` tells the UI to use the `index-list` template to render this page, effectively rendering the list of data defined in `page-index-data`.

Here's an example of the rendered output:
![2024-12-11_16-32-57](https://github.com/user-attachments/assets/d7b32585-ebe6-4344-8da5-b050cab6de4f)

