### PR TITLE
Bump version of actions/cache to v4

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Cache node_modules
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
From github:

> Starting February 1st, 2025, we are closing down v1-v2 of actions/cache (read more about it in this changelog announcement) as well as all previous versions of the @actions/cache package in actions/toolkit.