### PR TITLE
feat: Display notification banners for versions that are nearing end-of-life

### DIFF
--- a/src/css/banners.css
+++ b/src/css/banners.css
@@ -7,3 +7,11 @@
   margin-top: 0;
   margin-bottom: 10px;
 }
+
+.banner-container.nearing-eol {
+  background-color: var(--caution-background);
+}
+
+.banner-container.past-eol {
+  background-color: var(--warning-background);
+}

--- a/src/helpers/resolve-resource.js
+++ b/src/helpers/resolve-resource.js
@@ -1,14 +1,14 @@
 'use strict'
 
-module.exports = (spec, { data, hash: context }) => {
-  if (spec.startsWith('http')) {
-    return spec
+module.exports = (resource, { data, hash: context }) => {
+  if (resource.startsWith('http')) {
+    return resource
   }
   const { contentCatalog, page } = data.root
   if (page.component) {
     context = Object.assign({ component: page.component.name, version: page.version, module: page.module }, context)
   }
-  const file = contentCatalog.resolveResource(spec, context)
+  const file = contentCatalog.resolveResource(resource, context)
   if (!file) return
   return file.pub.url
 }

--- a/src/partials/latest-banner.hbs
+++ b/src/partials/latest-banner.hbs
@@ -4,23 +4,39 @@
 {{#with (log-missing this ./missing @root.page.url)}}
 {{/with}}
 {{/if}}
-<div class="banner-container" id="latest-banner">
+<div class="banner-container {{#if @root.page.attributes.is-nearing-eol}} nearing-eol{{else @root.page.attributes.is-past-eol}} past-eol{{/if}}" id="latest-banner">
   {{#if (and @root.page.componentVersion.prerelease (not ./prerelease))}}
-    <div>You are viewing the {{@root.page.component.title}} <b>v{{@root.page.version}}</b> beta documentation.
+    <div>You are viewing the {{@root.page.component.title}} <b>v{{@root.page.version}} beta</b> documentation.
     <br>We welcome your feedback at the <a href="https://redpandacommunity.slack.com/archives/C04N3C10VUL">Redpanda Community Slack #beta-feedback channel</a>.
+    </div>
+    <div>
+      To view the latest available version of the docs, see <a href="{{relativize ./url}}">v{{@root.page.component.latest.version}}</a>.
+    </div>
+  {{else if @root.page.attributes.is-nearing-eol}}
+    <div>
+      This version will reach its <a href="{{ @root.page.attributes.eol-doc}}" target="_blank"><b>end of life</b></a> on <b>{{ @root.page.attributes.eol-date}}</b>.
+      Please <a href="{{resolve-resource  @root.page.attributes.upgrade-doc}}">upgrade to a supported version</a>.
+    </div>
+  {{else if  @root.page.attributes.is-past-eol}}
+    <div>
+      This version is <a href="{{ @root.page.attributes.eol-doc}}" target="_blank"><b>no longer supported</b>. It reached its end of life on <b>{{ @root.page.attributes.eol-date}}</b>.
+      Please <a href="{{resolve-resource  @root.page.attributes.upgrade-doc}}">upgrade to a supported version</a>.
     </div>
   {{else if (eq @root.page.attributes.eol true)}}
     <div>
-      This is documentation for {{@root.page.component.title}} <b>v{{@root.page.version}}</b>, which is <a href="https://support.redpanda.com/hc/en-us/articles/20617574366743-Redpanda-Supported-Versions">no longer supported</a>.
+      This is documentation for {{@root.page.component.title}} <b>v{{@root.page.version}}</b>, which is <a href="https://support.redpanda.com/hc/en-us/articles/20617574366743-Redpanda-Supported-Versions"><b>no longer supported</b></a>.
+    </div>
+    <div>
+      To view the latest available version of the docs, see <a href="{{relativize ./url}}">v{{@root.page.component.latest.version}}</a>.
     </div>
   {{else}}
     <div>
       This is documentation for {{@root.page.component.title}} <b>v{{@root.page.version}}</b>.
     </div>
+    <div>
+      To view the latest available version of the docs, see <a href="{{relativize ./url}}">v{{@root.page.component.latest.version}}</a>.
+    </div>
   {{/if}}
-  <div>
-    To view the latest available version of the docs, see <a href="{{relativize ./url}}">v{{@root.page.component.latest.version}}</a>.
-  </div>
 </div>
 {{/with}}
 {{/unless}}


### PR DESCRIPTION
This PR updates the UI templates to display dynamic banners based on the lifecycle stage of docs versions. The banners leverage page attributes injected by the `compute-end-of-life` extension to inform users when a docs version is nearing EoL, past EoL, or still active.

![2025-01-13_17-00-49](https://github.com/user-attachments/assets/ea22d06a-eeed-4ceb-a817-f0658a6b7cde)


These UI changes improve transparency and user experience by clearly communicating the status of each docs version and providing actionable links for upgrading or reviewing EoL policies.

The UI displays banners based on the following states:

- Nearing EoL: Indicates the docs version will reach its EoL within the configured warning period.
- Past EoL: Indicates the docs version has reached its EoL and is no longer supported.

Relies on: https://github.com/redpanda-data/docs-extensions-and-macros/pull/92