### PR TITLE
DOC-1069 Adds the ability to set announcements on the pages too

### DIFF
--- a/src/css/bloblang-playground.css
+++ b/src/css/bloblang-playground.css
@@ -25,17 +25,19 @@
 }
 
 .bloblang-playground .banner-container {
-  display: flex;
+  display: none;
   position: relative;
   flex-wrap: wrap;
   gap: 10px;
   align-items: center;
 }
 
-.bloblang-playground .banner-container .close-button {
+.bloblang-playground .banner-container .close {
   position: absolute;
   top: 10px;
   right: 10px;
+  margin-top: 0;
+  padding: 0;
   background: transparent;
   border: none;
   font-size: 20px;
@@ -44,7 +46,7 @@
   transition: color 0.3s, transform 0.2s;
 }
 
-.bloblang-playground .banner-container .close-button:hover {
+.bloblang-playground .banner-container .close:hover {
   color: #000000;
   transform: scale(1.2);
 }
@@ -312,7 +314,7 @@
 }
 
 @media (max-width: 600px) {
-  .bloblang-playground .banner-container .close-button {
+  .bloblang-playground .banner-container .close {
     top: 5px;
     right: 5px;
     font-size: 18px;

--- a/src/partials/announcement-bar.hbs
+++ b/src/partials/announcement-bar.hbs
@@ -1,10 +1,13 @@
-{{#if (and (ne page.component.name 'api') (or site.keys.announcement page.component.latest.asciidoc.attributes.announcement-text))}}
+{{#if (and (ne page.component.name 'api') (or page.attributes.announcement page.component.latest.asciidoc.attributes.announcement site.keys.announcement))}}
 <div class="announcement-bar" role="banner" id="announcement">
   <div class="announcement-content">
-    {{#if page.component.latest.asciidoc.attributes.announcement-text}}
+    {{#if page.attributes.announcement}}
+      {{page.attributes.announcement-text}}
+      <a href="{{{page.attributes.announcement-link}}}">{{page.attributes.announcement-link-text}}</a>
+    {{else if page.component.latest.asciidoc.attributes.announcement}}
       {{page.component.latest.asciidoc.attributes.announcement-text}}
       <a href="{{{page.component.latest.asciidoc.attributes.announcement-link}}}">{{page.component.latest.asciidoc.attributes.announcement-link-text}}</a>
-    {{else}}
+    {{else if site.keys.announcement}}
       {{site.keys.announcementText}}
       <a href="{{{site.keys.announcementLink}}}">{{site.keys.announcementLinkText}}</a>
     {{/if}}

--- a/src/partials/announcement-bar.hbs
+++ b/src/partials/announcement-bar.hbs
@@ -1,16 +1,13 @@
-{{#if (and (ne page.component.name 'api') (or page.attributes.announcementText site.keys.announcementText))}}
-<div class="announcement-bar" role="banner" id="announcement">
+{{#if (and (ne page.component.name 'api') (or site.keys.announcement page.attributes.announcementText))}}
+<div class="announcement-bar" role="banner" id="announcement"
+     {{#if page.attributes.domainWide}}data-domain="{{page.component.name}}"{{/if}}>
   <div class="announcement-content">
     {{#if page.attributes.announcementText}}
       {{page.attributes.announcementText}}
-      {{#if page.attributes.announcementLink}}
-        <a href="{{{page.attributes.announcementLink}}}">{{page.attributes.announcementLinkText}}</a>
-      {{/if}}
+      <a href="{{{page.attributes.announcementLink}}}">{{page.attributes.announcementLinkText}}</a>
     {{else}}
       {{site.keys.announcementText}}
-      {{#if site.keys.announcementLink}}
-        <a href="{{{site.keys.announcementLink}}}">{{site.keys.announcementLinkText}}</a>
-      {{/if}}
+      <a href="{{{site.keys.announcementLink}}}">{{site.keys.announcementLinkText}}</a>
     {{/if}}
   </div>
   <button id="close-announcement" type="button" aria-label="close" class="close">

--- a/src/partials/announcement-bar.hbs
+++ b/src/partials/announcement-bar.hbs
@@ -1,4 +1,20 @@
-{{#if (and site.keys.announcement (ne page.component.name 'api'))}}
-<div class="announcement-bar" role="banner" id="announcement"><div class="announcement-content"> {{site.keys.announcementText}} <a href="{{{site.keys.announcementLink}}}">{{site.keys.announcementLinkText}}</a>
-</div><button id="close-announcement" type="button" aria-label="close" class="close"><svg viewBox="0 0 15 15" width="14" height="14"><g stroke="currentColor" stroke-width="3.1"><path d="M.75.75l13.5 13.5M14.25.75L.75 14.25"></path></g></svg></button></div>
+{{#if (and (ne page.component.name 'api') (or page.attributes.announcementText site.keys.announcementText))}}
+<div class="announcement-bar" role="banner" id="announcement">
+  <div class="announcement-content">
+    {{#if page.attributes.announcementText}}
+      {{page.attributes.announcementText}}
+      {{#if page.attributes.announcementLink}}
+        <a href="{{{page.attributes.announcementLink}}}">{{page.attributes.announcementLinkText}}</a>
+      {{/if}}
+    {{else}}
+      {{site.keys.announcementText}}
+      {{#if site.keys.announcementLink}}
+        <a href="{{{site.keys.announcementLink}}}">{{site.keys.announcementLinkText}}</a>
+      {{/if}}
+    {{/if}}
+  </div>
+  <button id="close-announcement" type="button" aria-label="close" class="close">
+    <svg viewBox="0 0 15 15" width="14" height="14"><g stroke="currentColor" stroke-width="3.1"><path d="M.75.75l13.5 13.5M14.25.75L.75 14.25"></path></g></svg>
+  </button>
+</div>
 {{/if}}

--- a/src/partials/announcement-bar.hbs
+++ b/src/partials/announcement-bar.hbs
@@ -1,10 +1,10 @@
-{{#if (and (ne page.component.name 'api') (or site.keys.announcement page.attributes.announcementText))}}
+{{#if (and (ne page.component.name 'api') (or site.keys.announcement page.component.latest.asciidoc.attributes.announcement-text))}}
 <div class="announcement-bar" role="banner" id="announcement"
-     {{#if page.attributes.domainWide}}data-domain="{{page.component.name}}"{{/if}}>
+     {{#if page.component.latest.asciidoc.attributes.domain-wide}}data-domain="{{page.component.name}}"{{/if}}>
   <div class="announcement-content">
-    {{#if page.attributes.announcementText}}
-      {{page.attributes.announcementText}}
-      <a href="{{{page.attributes.announcementLink}}}">{{page.attributes.announcementLinkText}}</a>
+    {{#if page.component.latest.asciidoc.attributes.announcement-text}}
+      {{page.component.latest.asciidoc.attributes.announcement-text}}
+      <a href="{{{page.component.latest.asciidoc.attributes.announcement-link}}}">{{page.component.latest.asciidoc.attributes.announcement-link-text}}</a>
     {{else}}
       {{site.keys.announcementText}}
       <a href="{{{site.keys.announcementLink}}}">{{site.keys.announcementLinkText}}</a>

--- a/src/partials/announcement-bar.hbs
+++ b/src/partials/announcement-bar.hbs
@@ -1,6 +1,5 @@
 {{#if (and (ne page.component.name 'api') (or site.keys.announcement page.component.latest.asciidoc.attributes.announcement-text))}}
-<div class="announcement-bar" role="banner" id="announcement"
-     {{#if page.component.latest.asciidoc.attributes.domain-wide}}data-domain="{{page.component.name}}"{{/if}}>
+<div class="announcement-bar" role="banner" id="announcement">
   <div class="announcement-content">
     {{#if page.component.latest.asciidoc.attributes.announcement-text}}
       {{page.component.latest.asciidoc.attributes.announcement-text}}

--- a/src/partials/announcement-bar.hbs
+++ b/src/partials/announcement-bar.hbs
@@ -1,5 +1,6 @@
 {{#if (and (ne page.component.name 'api') (or page.attributes.announcement page.component.latest.asciidoc.attributes.announcement site.keys.announcement))}}
-<div class="announcement-bar" role="banner" id="announcement">
+<div class="announcement-bar" role="banner" id="announcement"
+     data-announcement-key="{{#if page.attributes.announcement}}page-{{page.component.name}}-{{page.relativeSrcPath}}{{else if page.component.latest.asciidoc.attributes.announcement}}component-{{page.component.name}}{{else if site.keys.announcement}}site-global{{/if}}">
   <div class="announcement-content">
     {{#if page.attributes.announcement}}
       {{page.attributes.announcement-text}}

--- a/src/partials/bloblang-playground.hbs
+++ b/src/partials/bloblang-playground.hbs
@@ -74,7 +74,7 @@ function initializeAceEditor(editorId, mode, readOnly = false, initialValue = ''
   editor.setTheme('ace/theme/github');
   editor.session.setMode(mode);
   editor.setReadOnly(readOnly);
-  editor.setValue(prettifyJSON(initialValue), 1);
+  editor.setValue(initialValue, 1);
   editor.session.setTabSize(TAB_SIZE);
   editor.session.setUseSoftTabs(true);
   editor.setOptions({

--- a/src/partials/bloblang-signup-form.hbs
+++ b/src/partials/bloblang-signup-form.hbs
@@ -1,5 +1,5 @@
 <div class="banner-container" id="bloblang-banner">
-  <button class="close-button" id="dismiss-banner" aria-label="Dismiss">&times;</button>
+  <button class="close" id="dismiss-banner" aria-label="Dismiss">&times;</button>
   <p>Sign up for updates about new features in the playground:</p>
   <form  data-netlify="true" name="bloblang-emails" method="POST" netlify-honeypot="bot-field" id="bloblang-form" class="banner-form">
     <input type="email" name="email" id="bloblang-email" placeholder="Enter your email..." required />
@@ -10,16 +10,6 @@
 document.addEventListener("DOMContentLoaded", () => {
   const banner = document.getElementById("bloblang-banner");
   const form = document.getElementById("bloblang-form");
-  const dismissButton = document.getElementById("dismiss-banner");
-  if (sessionStorage.getItem("bloblangBannerDismissed") === "true" && banner) {
-    banner.style.display = "none";
-  }
-    if (dismissButton) {
-    dismissButton.addEventListener("click", () => {
-      banner.style.display = "none";
-      sessionStorage.setItem("bloblangBannerDismissed", "true");
-    });
-  }
   if (form) {
     form.addEventListener("submit", (event) => {
       event.preventDefault();

--- a/src/partials/head.hbs
+++ b/src/partials/head.hbs
@@ -1,8 +1,10 @@
-<!-- Inline CSS to Hide Announcement Bar Initially -->
 <style>
   .announcement-bar {
     display: none;
     height: 0;
+  }
+  .bloblang-playground .banner-container {
+    display: none;
   }
 </style>
 <script>
@@ -15,12 +17,22 @@
       const storageKey = `${sessionKey}-${announcementType}`; // Use the announcement type to differentiate between different banners
       const hasSeenBanner = window.sessionStorage.getItem(storageKey) || false;
       if (hasSeenBanner) {
+        if (announcementType !== 'bloblang') {
+          document.documentElement.style.setProperty('--announcement-bar-height', '0px');
+          document.documentElement.style.setProperty('--announcement-bar-height--desktop', '0px');
+        }
         banner.remove();
       } else {
+          if (announcementType !== 'bloblang') {
+            document.documentElement.style.setProperty('--announcement-bar-height', '50px');
+            document.documentElement.style.setProperty('--announcement-bar-height--desktop', '30px');
+          }
         banner.style.display = 'flex';
-        const closeButton = banner.querySelector('.close-button');
+        const closeButton = banner.querySelector('.close');
         if (closeButton) {
           closeButton.addEventListener('click', function () {
+            document.documentElement.style.setProperty('--announcement-bar-height', '0px');
+            document.documentElement.style.setProperty('--announcement-bar-height--desktop', '0px');
             banner.remove();
             window.sessionStorage.setItem(storageKey, 'true');
           });
@@ -33,19 +45,11 @@
       (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
 
     document.documentElement.setAttribute('data-theme', initialTheme);
-
-    document.addEventListener('DOMContentLoaded', function() {
-      const announcementBar = document.getElementById('announcement');
-      if (!announcementBar) return;
-
-      const announcementLevel = announcementBar.getAttribute('data-announcement-key');
-      handleBanner('announcement', 'announcementClosed', announcementLevel);
-      handleBanner('bloblang-banner', 'bloblangBannerDismissed', 'bloblang');
-    });
     // This script and the styles must be in the head to avoid flashing when the default white background changes to dark https://github.com/redpanda-data/docs-ui/pull/174
     window.addEventListener('DOMContentLoaded', function() {
       const switchButton = document.getElementById('switch-theme');
       const announcementBar = document.getElementById('announcement');
+      let announcementLevel = '';
       if (switchButton) {
         setTheme(initialTheme);  // Apply initial theme on load
         switchButton.addEventListener('click', function() {
@@ -56,24 +60,11 @@
           setTheme(newTheme);
         });
       }
-      if (!announcementBar) return;
-      const hasSeenAnnouncement = window.sessionStorage.getItem('announcementClosed') || window.localStorage.getItem('announcementClosed') || false;
-      if (!hasSeenAnnouncement) {
-        document.documentElement.style.setProperty('--announcement-bar-height', '50px');
-        document.documentElement.style.setProperty('--announcement-bar-height--desktop', '30px');
-        announcementBar.style.display = 'flex';
-      } else {
-        document.documentElement.style.setProperty('--announcement-bar-height', '0px');
-        document.documentElement.style.setProperty('--announcement-bar-height--desktop', '0px');
+      if (announcementBar) {
+        announcementLevel = announcementBar.getAttribute('data-announcement-key');
+        handleBanner('announcement', 'announcementClosed', announcementLevel);
       }
-      var closeButton = document.getElementById('close-announcement');
-      if (!closeButton) return;
-      closeButton.addEventListener('click', function () {
-        document.documentElement.style.setProperty('--announcement-bar-height', '0px');
-        document.documentElement.style.setProperty('--announcement-bar-height--desktop', '0px');
-        announcementBar.remove();
-        window.sessionStorage.setItem('announcementClosed', 'true');
-      });
+      handleBanner('bloblang-banner', 'bloblangBannerDismissed', 'bloblang');
     });
   function setTheme(theme) {
     const rapidocEl = document.getElementById('api');

--- a/src/partials/head.hbs
+++ b/src/partials/head.hbs
@@ -12,7 +12,10 @@
       const banner = document.getElementById(bannerId);
       if (!banner) return;
 
-      const hasSeenBanner = window.sessionStorage.getItem(sessionKey) || false;
+      const pagePath = window.location.pathname;
+      const pageSpecificKey = `${sessionKey}-${pagePath}`;
+
+      const hasSeenBanner = window.sessionStorage.getItem(pageSpecificKey) || false;
       if (hasSeenBanner) {
         banner.remove();
       } else {
@@ -21,7 +24,7 @@
         if (closeButton) {
           closeButton.addEventListener('click', function () {
             banner.remove();
-            window.sessionStorage.setItem(sessionKey, 'true');
+            window.sessionStorage.setItem(pageSpecificKey, 'true');
           });
         }
       }

--- a/src/partials/head.hbs
+++ b/src/partials/head.hbs
@@ -12,10 +12,7 @@
       const banner = document.getElementById(bannerId);
       if (!banner) return;
 
-      // Check if this is a domain-wide announcement
-      const domain = banner.getAttribute('data-domain');
-      const storageKey = domain ? `${sessionKey}-${domain}` : sessionKey;
-
+      const storageKey = sessionKey;
       const hasSeenBanner = window.sessionStorage.getItem(storageKey) || false;
       if (hasSeenBanner) {
         banner.remove();

--- a/src/partials/head.hbs
+++ b/src/partials/head.hbs
@@ -8,11 +8,11 @@
 <script>
   (function() {
     'use strict';
-    function handleBanner(bannerId, sessionKey) {
+    function handleBanner(bannerId, sessionKey, announcementType) {
       const banner = document.getElementById(bannerId);
       if (!banner) return;
 
-      const storageKey = sessionKey;
+      const storageKey = `${sessionKey}-${announcementType}`; // Use the announcement type to differentiate between different banners
       const hasSeenBanner = window.sessionStorage.getItem(storageKey) || false;
       if (hasSeenBanner) {
         banner.remove();
@@ -35,8 +35,12 @@
     document.documentElement.setAttribute('data-theme', initialTheme);
 
     document.addEventListener('DOMContentLoaded', function() {
-      handleBanner('announcement', 'announcementClosed');
-      handleBanner('bloblang-banner', 'bloblangBannerDismissed');
+      const announcementBar = document.getElementById('announcement');
+      if (!announcementBar) return;
+
+      const announcementLevel = announcementBar.getAttribute('data-announcement-key');
+      handleBanner('announcement', 'announcementClosed', announcementLevel);
+      handleBanner('bloblang-banner', 'bloblangBannerDismissed', 'bloblang');
     });
     // This script and the styles must be in the head to avoid flashing when the default white background changes to dark https://github.com/redpanda-data/docs-ui/pull/174
     window.addEventListener('DOMContentLoaded', function() {

--- a/src/partials/head.hbs
+++ b/src/partials/head.hbs
@@ -12,10 +12,11 @@
       const banner = document.getElementById(bannerId);
       if (!banner) return;
 
-      const pagePath = window.location.pathname;
-      const pageSpecificKey = `${sessionKey}-${pagePath}`;
+      // Check if this is a domain-wide announcement
+      const domain = banner.getAttribute('data-domain');
+      const storageKey = domain ? `${sessionKey}-${domain}` : sessionKey;
 
-      const hasSeenBanner = window.sessionStorage.getItem(pageSpecificKey) || false;
+      const hasSeenBanner = window.sessionStorage.getItem(storageKey) || false;
       if (hasSeenBanner) {
         banner.remove();
       } else {
@@ -24,7 +25,7 @@
         if (closeButton) {
           closeButton.addEventListener('click', function () {
             banner.remove();
-            window.sessionStorage.setItem(pageSpecificKey, 'true');
+            window.sessionStorage.setItem(storageKey, 'true');
           });
         }
       }


### PR DESCRIPTION
Adds the support to make announcements for specific pages/products/site. 

## Usage

To add a page-specific announcement add these keys in your page:

```asciidoc
:page-announcement: true
:page-announcement-text: Page-specific announcement
:page-announcement-link: 'Learn more.'
:page-announcement-link-text: 'http://mylink.here.com'
```

To add a product-wide announcement, add those keys in the corresponding `antora.yaml` file:
```yml
asciidoc:
  attributes:
    keys:
      announcement: true
      announcement-text: 'product-wide test'
      announcement-link-text: 'Learn more.'
      announcement-link: 'http://mylink.here.com'
```

To add a site-wide announcement, continue adding the keys in the corresponding site yaml (playbook). Example with `local-antora-playbook.yaml`: 

```yml
site:
  keys:
    announcement: true
    announcement-text: 'Site-wide announcement.'
    announcement-link-text: 'Learn more.'
    announcement-link: 'http://mylink.here.com'
```

The implementation respects the following order:
page > product > site 

PS.
The file announcement-bar was auto-idented, that's why the changes look bigger than they are.  