### PR TITLE
Add support for expandable SVGs using modals

### DIFF
--- a/src/css/expandable-images.css
+++ b/src/css/expandable-images.css
@@ -14,7 +14,8 @@
   position: relative;
 }
 
-.imageblock .content img {
+.imageblock .content img,
+.imageblock .content svg {
   max-width: 100%;
   max-height: 100%;
   -webkit-transition: all 0.3s ease;
@@ -22,22 +23,59 @@
   cursor: pointer;
 }
 
-.imageblock .content img.active {
+.modal-overlay {
   position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  max-width: 100%;
-  max-height: 100%;
-  object-fit: contain;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.8);
+  display: none; /* Shown when active */
+  align-items: center;
+  justify-content: center;
+  overflow: auto;  /* Allows scrolling if content is too tall */
+  padding: 1rem;
   z-index: 9999;
-  cursor: zoom-out;
+}
+
+.modal-overlay.active {
+  display: flex;
+}
+
+.modal-scroll-container {
+  max-width: 90vw;
+  max-height: 90vh;
+}
+
+.modal-scroll-container img,
+.modal-scroll-container svg {
+  width: 100%;
+  height: auto;
+  object-fit: contain;
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
   border-radius: 5px;
 }
 
+.modal-scroll-container svg {
+  width: 90vw;
+  object-fit: unset;
+}
+
+.modal-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: transparent;
+  border: none;
+  font-size: 2rem;
+  color: #fff;
+  cursor: pointer;
+  z-index: 10000;
+}
+
 @media (prefers-reduced-motion: reduce) {
-  .imageblock .content img {
+  .imageblock .content img,
+  .imageblock .content svg {
     -webkit-transition: none;
     transition: none;
   }

--- a/src/js/07-expand-images.js
+++ b/src/js/07-expand-images.js
@@ -1,22 +1,42 @@
-;(function () {
+(function () {
   'use strict'
-  const images = document.querySelectorAll('.imageblock img')
 
-  if (!images) return
+  const modalOverlay = document.createElement('div')
+  modalOverlay.id = 'modal-overlay'
+  modalOverlay.className = 'modal-overlay'
+  // Create the inner HTML (close button and container for media)
+  modalOverlay.innerHTML = `
+    <button id="modal-close" class="modal-close">&times;</button>
+    <div class="modal-scroll-container"></div>
+  `
+  document.body.appendChild(modalOverlay)
 
-  images.forEach((image) => {
-    image.addEventListener('click', (e) => {
-      image.classList.toggle('active')
+  const blocks = document.querySelectorAll('.imageblock')
+  const modalContainer = document.querySelector('.modal-scroll-container')
+  const modalClose = document.getElementById('modal-close')
+
+  if (!blocks.length || !modalOverlay) return
+
+  blocks.forEach((block) => {
+    block.addEventListener('click', function (e) {
+      const media = block.querySelector('img, svg')
+      if (!media) return
+
+      const clone = media.cloneNode(true)
+      modalContainer.innerHTML = ''
+      modalContainer.appendChild(clone)
+      modalOverlay.classList.add('active')
     })
+    block.addEventListener('touchmove', (e) => e.preventDefault())
+  })
 
-    image.addEventListener('touchmove', function (e) {
-      e.preventDefault()
-    })
+  modalClose.addEventListener('click', () => {
+    modalOverlay.classList.remove('active')
+  })
 
-    image.addEventListener('touchend', function (e) {
-      if (!e.target.classList.contains('active')) {
-        e.preventDefault()
-      }
-    })
+  modalOverlay.addEventListener('click', function (e) {
+    if (e.target === modalOverlay) {
+      modalOverlay.classList.remove('active')
+    }
   })
 })()


### PR DESCRIPTION
This PR introduces a dynamic modal overlay for enlarging images and SVGs contained within elements marked with the `.imageblock` class. The modal overlay is created on-the-fly using JavaScript, ensuring that users on both desktop and mobile devices can view large media in an easily scrollable, centered modal with a close button.
![2025-02-19_15-42-10 (1)](https://github.com/user-attachments/assets/0493be79-24e4-4a0d-a3ac-b704b75cf6b2)
