### PR TITLE
Add the ability to have code blocks scroll horizontally instead of wrap

### DIFF
--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -155,6 +155,17 @@ vfs
 <.> Wrap each streaming file in a buffer so the files can be processed by uglify.
 Uglify can only work with buffers, not streams.
 
+This code won't wrap. It'll scroll.
+
+[role="no-wrap"]
+----
++-----------------------------------+---------+--------------+--------------------------+
+| redpanda                          | user_id | event_type   | ts                       |
++-----------------------------------+---------+--------------+--------------------------+
+| {"partition":0,"offset":0,"timestamp":2025-03-05 15:09:20.436,"headers":null,"key":null} | 2324    | BUTTON_CLICK | 2024-11-25T20:23:59.380Z |
++-----------------------------------+---------+--------------+--------------------------+
+----
+
 Execute these commands to validate and build your site:
 
  $ podman run -v $PWD:/antora:Z --rm -t antora/antora \

--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -157,7 +157,7 @@ Uglify can only work with buffers, not streams.
 
 This code won't wrap. It'll scroll.
 
-[role="no-wrap"]
+[,bash,role="no-wrap"]
 ----
 +-----------------------------------+---------+--------------+--------------------------+
 | redpanda                          | user_id | event_type   | ts                       |

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -981,6 +981,11 @@ details[open] > summary {
   font-weight: 300;
 }
 
+.doc div.no-wrap pre code {
+  white-space: pre !important;
+  overflow-x: auto !important;
+}
+
 .doc .literalblock pre {
   padding-left: 1em;
 }

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -984,6 +984,8 @@ details[open] > summary {
 .doc div.no-wrap pre code {
   white-space: pre !important;
   overflow-x: auto !important;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
 }
 
 .doc .literalblock pre {


### PR DESCRIPTION
Use the following syntax:

```
[source,yaml,role=no-wrap]
----
This is a code block that I want to scroll.
----
```

Test case: https://deploy-preview-265--docs-ui.netlify.app/#some-code:~:text=This%20code%20won%E2%80%99t%20wrap.%20It%E2%80%99ll%20scroll.