### PR TITLE
gha: add permissions to publish-release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache@v4


### PR DESCRIPTION
jira: [DEVPROD-2713]

fixes [error](https://github.com/redpanda-data/docs-ui/actions/runs/13727328633/job/38396784217#step:6:9) by granting permissions according to [docs](https://docs.github.com/en/enterprise-cloud@latest/rest/releases/releases?apiVersion=2022-11-28#create-a-release):

> "Contents" repository permissions (write)

after this pr is merged, will need to tag again to release.

[DEVPROD-2713]: https://redpandadata.atlassian.net/browse/DEVPROD-2713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ