### PR TITLE
Remove class selector for the close class

### DIFF
--- a/src/css/modal.css
+++ b/src/css/modal.css
@@ -81,7 +81,6 @@ html[data-theme=dark] .modal-content button:hover {
   color: var(--body-font-color);
 }
 
-.close,
 .close-modal {
   position: sticky;
   top: 1rem;


### PR DESCRIPTION
This pull request includes a small change to the `src/css/modal.css` file. The change removes the `.close` selector from the CSS rule for modal content buttons. This selector was a bug that caused the close button for the announcement bar to disappear.