### PR TITLE
Fix a bug in the admin API migration step

### DIFF
--- a/console-config-migrator/main.go
+++ b/console-config-migrator/main.go
@@ -318,7 +318,7 @@ func migrateAdminAPI(v2 map[string]interface{}) (map[string]interface{}, error) 
 			for k, v := range adminApiRaw {
 				newAdminApi[k] = v
 			}
-			return redpandaRaw, nil
+			return newAdminApi, nil
 		}
 	}
 	return nil, nil

--- a/src/partials/console-config-migrator.hbs
+++ b/src/partials/console-config-migrator.hbs
@@ -38,10 +38,10 @@
     aceOutputEditor.session.setUseSoftTabs(true);
     aceOutputEditor.setReadOnly(true);
     aceOutputEditor.setValue("# The migrated v3 configuration will appear here...", 1);
-    clearButton.addEventListener("click", () => {
+    clearButton && clearButton.addEventListener("click", () => {
       aceInputEditor.setValue("# Paste your v2 YAML configuration here...", 1);
     });
-    copyButton.addEventListener("click", async () => {
+    copyButton && copyButton.addEventListener("click", async () => {
       try {
         const content = aceOutputEditor.getValue();
         await navigator.clipboard.writeText(content);
@@ -56,12 +56,12 @@
       }
     });
     // Convert button event handler: call the WASM module's convertYAML function.
-    migrateButton.addEventListener("click", () => {
+    migrateButton && migrateButton.addEventListener("click", () => {
       const input = aceInputEditor.getValue();
       const output = convertYAML(input);
       aceOutputEditor.setValue(output, 1);
     });
-    showExampleButton.addEventListener("click", () => {
+    showExampleButton && showExampleButton.addEventListener("click", () => {
       const sample = `login:
   jwtSecret: "example-secret"
   useSecureCookies: true


### PR DESCRIPTION
This pull request includes changes to the `console-config-migrator` to improve the migration process and add safety checks for event listeners in the UI. The most important changes include modifying the `Convert` and `migrateAdminAPI` functions to preserve the entire `redpanda` stanza and adding null checks for event listeners in the `console-config-migrator.hbs` file.

Improvements to migration process:

* [`console-config-migrator/main.go`](diffhunk://#diff-47b04c5fc99290c472eb8cdd8acca4d450638ccf514aed2f32d27d59acae20c0L79-R96): Modified the `Convert` function to preserve the entire `redpanda` stanza during the migration process.
* [`console-config-migrator/main.go`](diffhunk://#diff-47b04c5fc99290c472eb8cdd8acca4d450638ccf514aed2f32d27d59acae20c0L321-R332): Updated the `migrateAdminAPI` function to return the new `adminApi` map instead of the entire `redpanda` map.

UI enhancements:

* [`src/partials/console-config-migrator.hbs`](diffhunk://#diff-e2241b8f557cd7d505ba3cf68e45c6cbf8276a0ab0ef4b367ad36799a035c776L41-R44): Added null checks for `clearButton` and `copyButton` event listeners to prevent potential runtime errors.
* [`src/partials/console-config-migrator.hbs`](diffhunk://#diff-e2241b8f557cd7d505ba3cf68e45c6cbf8276a0ab0ef4b367ad36799a035c776L59-R64): Added null checks for `migrateButton` and `showExampleButton` event listeners to prevent potential runtime errors.


To test this change:

1. Go to https://deploy-preview-275--docs-ui.netlify.app/console-migrator
2. Paste the following and click **Migrate**
```
kafka:
  brokers: "rp.daeda.net:9092"
  sasl:
    enabled: true
    username: test
    password: super
    mechanism: SCRAM-SHA-256
  tls:
      enabled: false
      insecureSkipTlsVerify: true
  schemaRegistry:
    enabled: true
    urls: ["https://rp.daeda.net:8083"]
    username: test
    password: super
    tls:
      enabled: true
      # certFilepath: /etc/redpanda/fullchain.pem
      # keyFilepath: /etc/redpanda/privkey.pem
redpanda:
  adminApi:
    enabled: true
    urls: ["http://rp.daeda.net:9644"]
    username: "test"
    password: "super"
server:
  tls:
    enabled: true
    certFilepath: /etc/redpanda/fullchain.pem
    keyFilepath: /etc/redpanda/privkey.pem
```

The result should include the `redpanda.adminApi` stanza.