### PR TITLE
Add styles for listing block titles

### DIFF
--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -618,6 +618,11 @@ table code {
 
 .listingblock .title {
   margin-top: 0.5rem;
+  margin-top: .5rem;
+  font-style: italic;
+  background: var(--code-background);
+  padding: 5px;
+  border-bottom: 1px solid #e0e0e0;
 }
 
 .doc .imageblock,

--- a/src/css/doc.css
+++ b/src/css/doc.css
@@ -618,7 +618,6 @@ table code {
 
 .listingblock .title {
   margin-top: 0.5rem;
-  margin-top: .5rem;
   font-style: italic;
   background: var(--code-background);
   padding: 5px;


### PR DESCRIPTION
This pull request includes a small change to the `src/css/doc.css` file. The change enhances the styling of `.listingblock .title` elements by adding italic font style, background color, padding, and a bottom border.

Styling enhancements:

* [`src/css/doc.css`](diffhunk://#diff-3b3625188d2b785fa313ab757becb336d992aa00055616324a53aeaf9895cc3bR621-R625): Modified `.listingblock .title` to include italic font style, background color, padding, and a bottom border.