### PR TITLE
Fix `serde` migration function

### DIFF
--- a/console-config-migrator/main.go
+++ b/console-config-migrator/main.go
@@ -39,7 +39,7 @@ func Convert(v2 map[string]interface{}) (map[string]interface{}, string, error) 
 	}
 
 	// Migrate Kafka settings (including schemaRegistry and serde).
-	kafka, warnKafka, err := migrateKafka(v2)
+	kafka, serdeFromKafka, warnKafka, err := migrateKafka(v2)
 	if err != nil {
 		return nil, "", fmt.Errorf("kafka migration: %w", err)
 	}
@@ -58,11 +58,24 @@ func Convert(v2 map[string]interface{}) (map[string]interface{}, string, error) 
 	}
 
 	// Migrate console settings into serde.
-	serde, err := migrateConsole(v2)
+	serdeConsole, err := migrateConsole(v2)
 	if err != nil {
 		return nil, "", fmt.Errorf("console migration: %w", err)
 	}
-	v3["serde"] = serde
+
+	mergedSerde := make(map[string]interface{})
+	// Add serde settings from Kafka migration.
+	for key, val := range serdeFromKafka {
+		mergedSerde[key] = val
+	}
+	// Add or override with console settings.
+	for key, val := range serdeConsole {
+		mergedSerde[key] = val
+	}
+
+	if len(mergedSerde) > 0 {
+		v3["serde"] = mergedSerde
+	}
 
 	// Migrate roleBindings.
 	roleBindings, warnRB, err := migrateRoleBindings(v2)
@@ -119,7 +132,7 @@ func migrateAuthentication(v2 map[string]interface{}) (map[string]interface{}, [
 	if login, ok := v2["login"].(map[string]interface{}); ok {
 		auth := make(map[string]interface{})
 		if jwt, ok := login["jwtSecret"]; ok {
-			auth["jwtSigningSecret"] = jwt
+			auth["jwtSigningKey"] = jwt
 		}
 		if sc, ok := login["useSecureCookies"]; ok {
 			auth["useSecureCookies"] = sc
@@ -174,15 +187,19 @@ func migrateAuthentication(v2 map[string]interface{}) (map[string]interface{}, [
 }
 
 // migrateKafka handles the migration of Kafka settings and schemaRegistry.
-func migrateKafka(v2 map[string]interface{}) (map[string]interface{}, []string, error) {
+func migrateKafka(v2 map[string]interface{}) (map[string]interface{}, map[string]interface{}, []string, error) {
 	var warnings []string
 	kafka := make(map[string]interface{})
+	// Default SASL settings.
 	kafka["sasl"] = map[string]interface{}{
 		"enabled":         true,
 		"impersonateUser": true,
 	}
+	// This will hold serde settings from kafka stanza.
+	serde := make(map[string]interface{})
+
 	if oldKafka, ok := v2["kafka"].(map[string]interface{}); ok {
-		// Process schemaRegistry from v2 (which is under kafka) and later promote it to top-level.
+		// Process schemaRegistry from v2 (which is under kafka)...
 		if srRaw, ok := oldKafka["schemaRegistry"].(map[string]interface{}); ok {
 			newSR := make(map[string]interface{})
 			authBlock := make(map[string]interface{})
@@ -211,12 +228,10 @@ func migrateKafka(v2 map[string]interface{}) (map[string]interface{}, []string, 
 			for k, v := range srRaw {
 				newSR[k] = v
 			}
-			// Instead of adding newSR into kafka, we'll let Convert() extract it.
 			kafka["schemaRegistry"] = newSR
 		}
 
 		// Migrate serde settings.
-		serde := make(map[string]interface{})
 		if proto, ok := oldKafka["protobuf"]; ok {
 			serde["protobuf"] = proto
 		}
@@ -234,21 +249,21 @@ func migrateKafka(v2 map[string]interface{}) (map[string]interface{}, []string, 
 			kafka[key] = val
 		}
 	}
-	return kafka, warnings, nil
+	return kafka, serde, warnings, nil
 }
 
-// migrateConsole moves console.maxDeserializationPayloadSize into a serde.console block.
+
+// migrateConsole moves console.maxDeserializationPayloadSize into a serde block.
 func migrateConsole(v2 map[string]interface{}) (map[string]interface{}, error) {
 	serde := make(map[string]interface{})
 	if console, ok := v2["console"].(map[string]interface{}); ok {
 		if maxPayload, ok := console["maxDeserializationPayloadSize"]; ok {
-			serde["console"] = map[string]interface{}{
-				"maxDeserializationPayloadSize": maxPayload,
-			}
+			serde["maxDeserializationPayloadSize"] = maxPayload
 		}
 	}
 	return serde, nil
 }
+
 
 // migrateRoleBindings converts v2 roleBindings into v3 authorization.roleBindings.
 func migrateRoleBindings(v2 map[string]interface{}) ([]interface{}, []string, error) {


### PR DESCRIPTION
Partially resolves https://github.com/redpanda-data/console/issues/1721

This pull request includes several changes to the `console-config-migrator/main.go` file, focusing on improving the migration of Kafka and console settings and updating the authentication migration. The most important changes are listed below:

### Kafka and Console Settings Migration:

* Modified `migrateKafka` function to return serde settings along with Kafka settings and warnings. This change ensures that serde settings from Kafka are correctly merged with console serde settings. [[1]](diffhunk://#diff-47b04c5fc99290c472eb8cdd8acca4d450638ccf514aed2f32d27d59acae20c0L177-R202) [[2]](diffhunk://#diff-47b04c5fc99290c472eb8cdd8acca4d450638ccf514aed2f32d27d59acae20c0L214-L219)
* Updated `Convert` function to merge serde settings from both Kafka and console migrations into a single `serde` block. This ensures that all serde settings are consolidated and correctly applied.

### Authentication Migration:

* Changed the key name from `jwtSigningSecret` to `jwtSigningKey` in the `migrateAuthentication` function.

These changes improve the overall configuration migration process by ensuring that settings are correctly merged and correctly named.

### Test case

Paste the following into the [migration tool](https://deploy-preview-278--docs-ui.netlify.app/console-migrator):

```yml
kafka:
  broker: "localhost:9092"
  schemaRegistry:
    username: "sruser"
    password: "srpass"
    bearerToken: "srbearer"
    url: "http://schema-registry:8081"
  protobuf:
    enabled: true
  cbor:
    enabled: false
  messagePack:
    enabled: true
```

You should see:

```yml
kafka:
  broker: "localhost:9092"
  sasl:
    enabled: true
    impersonateUser: true
schemaRegistry:
  authentication:
    basic:
      username: sruser
      password: srpass
    bearerToken: srbearer
    impersonateUser: false
  url: "http://schema-registry:8081"
serde:
  protobuf:
    enabled: true
  cbor:
    enabled: false
  messagePack:
    enabled: true
```