### PR TITLE
Lowercase beta

### DIFF
--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -28,7 +28,7 @@
 {{/if}}
 {{#if page.attributes.beta}}
   <div class="beta-label">
-    <p>Beta</p>
+    <p>beta</p>
   </div>
   <script>
   const betaButton = document.querySelector('.beta-label p');


### PR DESCRIPTION
Makes 'beta' lowercase across all our docs for consistency.