### PR TITLE
Switch to native Netlify form submission to enable reCAPTCHA

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -114,6 +114,23 @@ object[type="image/svg+xml"]:not([width]) {
   opacity: 0.5;
 }
 
+.captcha-hint {
+  margin: 0.5em 0;
+  color: #555;
+  font-size: small;
+  text-align: center;
+}
+
+button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button[disabled]:hover {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 @media (pointer: fine) {
   @supports (scrollbar-width: thin) {
     html {

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -114,7 +114,7 @@ object[type="image/svg+xml"]:not([width]) {
   opacity: 0.5;
 }
 
-.captcha-hint {
+.hint {
   margin: 0.5em 0;
   color: #555;
   font-size: small;

--- a/src/css/feedback-form.css
+++ b/src/css/feedback-form.css
@@ -22,6 +22,22 @@
   max-height: 80vh;
 }
 
+.feedback-toast {
+  margin-top: 1rem;
+  margin-bottom: 1em;
+  padding: 0.75rem 1rem;
+  background: var(--tip-background);
+  color: var(--tip-on-color);
+  border-left: 4px solid #27ae60;
+  font-size: 0.9rem;
+  border-radius: 4px;
+  max-width: 400px;
+}
+
+.feedback-toast.hidden {
+  display: none;
+}
+
 .feedback-modal textarea {
   font-family: inherit;
   font-size: 0.9rem;

--- a/src/css/feedback-form.css
+++ b/src/css/feedback-form.css
@@ -61,6 +61,7 @@
 .feedback-modal .radio-buttons.form-field {
   display: flex;
   flex-direction: column;
+  gap: 15px;
 }
 
 .feedback-modal .form-field {

--- a/src/partials/announcement-email.hbs
+++ b/src/partials/announcement-email.hbs
@@ -1,6 +1,6 @@
 <div class="announcement-email" role="banner" id="announcement-email">
   <div class="row">
-    <form data-netlify="true" data-netlify-recaptcha="true" name="announcementEmail" method="POST" netlify-honeypot="bot-field" onSubmit="handleSubmitEmail(event)">
+    <form data-netlify="true" name="announcementEmail" method="POST" netlify-honeypot="bot-field" onSubmit="handleSubmitEmail(event)">
       <input type="hidden" name="form-name" value="announcementEmail">
       <p class="hidden">
         <label class="hidden">Beep-Boop. Bot-field <input name="bot-field"></label>
@@ -10,7 +10,6 @@
         <div>
           <input type="email" name="email" id="email" placeholder="Email" class="email-input" required><input type="submit" class="submit-announcement-button-email"></input>
         </div>
-        <div data-netlify-recaptcha="true"></div>
         <button id="close-announcement-email-footer" type="button" aria-label="close" class="close-announcement-email-footer">
           <svg viewBox="0 0 15 15" width="14" height="14">
             <g stroke="currentColor" stroke-width="2.4">

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -1,4 +1,7 @@
 <article class="doc {{#if page.attributes.no-toc}}no-toc{{/if}}">
+  <div id="feedback-toast" class="feedback-toast hidden" role="status" aria-live="polite">
+  🎉 Thanks for your feedback!
+  </div>
 {{#if (ne page.attributes.role 'home')}}
 {{> breadcrumbs}}
 {{/if}}

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -1,7 +1,5 @@
 <article class="doc {{#if page.attributes.no-toc}}no-toc{{/if}}">
-  <div id="feedback-toast" class="feedback-toast hidden" role="status" aria-live="polite">
-  🎉 Thanks for your feedback!
-  </div>
+  {{> feedback-success}}
 {{#if (ne page.attributes.role 'home')}}
 {{> breadcrumbs}}
 {{/if}}

--- a/src/partials/bloblang-signup-form.hbs
+++ b/src/partials/bloblang-signup-form.hbs
@@ -1,10 +1,9 @@
 <div class="banner-container" id="bloblang-banner">
   <button class="close" id="dismiss-banner" aria-label="Dismiss">&times;</button>
   <p>Sign up for updates about new features in the playground:</p>
-  <form  data-netlify="true" data-netlify-recaptcha="true" name="bloblang-emails" method="POST" netlify-honeypot="bot-field" id="bloblang-form" class="banner-form">
+  <form  data-netlify="true" name="bloblang-emails" method="POST" netlify-honeypot="bot-field" id="bloblang-form" class="banner-form">
     <input type="email" name="email" id="bloblang-email" placeholder="Enter your email..." required />
     <button class="button" type="submit">Sign up</button>
-    <div data-netlify-recaptcha="true"></div>
   </form>
 </div>
 <script>

--- a/src/partials/feedback-form-script.hbs
+++ b/src/partials/feedback-form-script.hbs
@@ -7,16 +7,21 @@ const feedbackPrompt = document.getElementById('feedback-prompt');
 let positive = null;
 
 // Scroll visibility toggle for thumbs
-document.addEventListener('scroll', function() {
-  const feedback = document.getElementById('thumbs-toc');
-  if (!feedback) return;
-
-  const modifier = 700;
-  const documentHeight = document.body.scrollHeight;
-  const currentScroll = window.scrollY + window.innerHeight;
-
-  feedback.style.display = (currentScroll + modifier > documentHeight) ? 'none' : 'block';
-});
+// `passive` signals we never call preventDefault, letting the browser optimise.
+// `requestAnimationFrame` throttles DOM writes to one per frame.
+document.addEventListener(
+  'scroll',
+  () => requestAnimationFrame(() => {
+    const feedback = document.getElementById('thumbs-toc');
+    if (!feedback) return;
+    const modifier = 700;
+    const documentHeight = document.body.scrollHeight;
+    const currentScroll = window.scrollY + window.innerHeight;
+    feedback.style.display =
+      currentScroll + modifier > documentHeight ? 'none' : 'block';
+  }),
+  { passive: true }
+);
 
 // Handle thumbs click
 thumbs.forEach(thumb => {
@@ -48,7 +53,7 @@ thumbs.forEach(thumb => {
 // Fill hidden metadata
 form.addEventListener('submit', () => {
   const version = "{{{ page.attributes.version }}}" || "";
-  const beta = {{ is-prerelease page }};
+  const beta = Boolean({{ is-prerelease page }} || false);
   const url = window.location.href;
   const nav = navigator.userAgent + ', ' + navigator.language;
   const selectedFeedback = form.querySelector('input[name="feedback"]:checked');

--- a/src/partials/feedback-form-script.hbs
+++ b/src/partials/feedback-form-script.hbs
@@ -68,21 +68,6 @@ function closeForm(event) {
   form.classList.add("hidden");
 }
 
-// Show thank-you modal on redirect
-function clearFeedbackModal() {
-  const modalBody = form.querySelector('.feedback-modal-body');
-  const type = sessionStorage.getItem("feedbackType");
-  sessionStorage.removeItem("feedbackType");
-
-  modalBody.innerHTML = `
-    <div class="feedback-success">
-      <h4>🎉 Thank you for your ${type === "positive" ? "positive" : "honest"} feedback!</h4>
-      <p>We appreciate your help improving our documentation.</p>
-      <button type="button" onclick="closeForm(event)">Close</button>
-    </div>
-  `;
-}
-
 window.addEventListener('DOMContentLoaded', () => {
   const toast = document.getElementById('feedback-toast');
   const modal = document.getElementById('feedbackForm');

--- a/src/partials/feedback-form-script.hbs
+++ b/src/partials/feedback-form-script.hbs
@@ -89,6 +89,8 @@
       submitBtn.disabled = true;
       hint.style.display = 'block';
       const start = Date.now();
+      // Enable the submit button when the reCAPTCHA token is available
+      // https://answers.netlify.com/t/recaptcha-integration-in-forms-configuration/6181/3
       const intervalId = setInterval(() => {
         const captcha = document.querySelector(SELECTORS.captchaField);
         if (captcha && captcha.value.trim() !== '') {

--- a/src/partials/feedback-form-script.hbs
+++ b/src/partials/feedback-form-script.hbs
@@ -1,98 +1,118 @@
 <script>
-const form = document.getElementById('feedbackForm');
-const thumbs = document.querySelectorAll('.thumb');
-const feedbackDetails = document.getElementById('feedback-details');
-const feedbackOptions = document.getElementById('feedback-options');
-const feedbackPrompt = document.getElementById('feedback-prompt');
-let positive = null;
+;
+(() => {
+  const SELECTORS = {
+    form: '#feedbackForm',
+    thumbs: '.thumb',
+    feedbackDetails: '#feedback-details',
+    feedbackOptions: '#feedback-options',
+    feedbackPrompt: '#feedback-prompt',
+    submitButton: '#submitButton',
+    captchaHint: '#captchaHint',
+    captchaField: 'textarea[name="g-recaptcha-response"]',
+    toast: '#feedback-toast',
+    modalOverlay: '#modal-overlay',
+    thumbsToc: '#thumbs-toc'
+  };
 
-// Scroll visibility toggle for thumbs
-// `passive` signals we never call preventDefault, letting the browser optimise.
-// `requestAnimationFrame` throttles DOM writes to one per frame.
-document.addEventListener(
-  'scroll',
-  () => requestAnimationFrame(() => {
-    const feedback = document.getElementById('thumbs-toc');
-    if (!feedback) return;
-    const modifier = 700;
-    const documentHeight = document.body.scrollHeight;
-    const currentScroll = window.scrollY + window.innerHeight;
-    feedback.style.display =
-      currentScroll + modifier > documentHeight ? 'none' : 'block';
-  }),
-  { passive: true }
-);
+  const POLL_INTERVAL = 300;            // ms between captcha checks
+  const POLL_TIMEOUT = 5 * 60 * 1000;   // stop polling after 5 minutes
+  const SCROLL_HIDE_OFFSET = 700;       // px before bottom to hide thumbs
 
-// Handle thumbs click
-thumbs.forEach(thumb => {
-  thumb.addEventListener('click', () => {
-    positive = thumb.id.includes('up');
-    form.querySelector('input[name="positiveFeedback"]').value = positive;
+  let positive = null;
 
-    feedbackOptions.innerHTML = positive
-      ? `
-        <label><input type="radio" name="feedback" value="Solved my problem" checked> Solved my problem</label>
-        <label><input type="radio" name="feedback" value="Easy to understand"> Easy to understand</label>
-        <label><input type="radio" name="feedback" value="other"> Other</label>
-      `
-      : `
-        <label><input type="radio" name="feedback" value="Not helpful" checked> Not helpful</label>
-        <label><input type="radio" name="feedback" value="Too complex"> Too complex</label>
-        <label><input type="radio" name="feedback" value="other"> Other</label>
-      `;
+  document.addEventListener('DOMContentLoaded', () => {
+    const form = document.querySelector(SELECTORS.form);
+    if (!form) return;
+    const thumbs = document.querySelectorAll(SELECTORS.thumbs);
+    const details = document.querySelector(SELECTORS.feedbackDetails);
+    const options = document.querySelector(SELECTORS.feedbackOptions);
+    const prompt = document.querySelector(SELECTORS.feedbackPrompt);
+    const submitBtn = document.querySelector(SELECTORS.submitButton);
+    const hint = document.querySelector(SELECTORS.captchaHint);
+    const toast = document.querySelector(SELECTORS.toast);
 
-    feedbackPrompt.textContent = positive
-      ? "Let us know what we do well:"
-      : "Let us know what could be improved:";
+    // Hide thumbs when scrolling to the bottom
+    document.addEventListener(
+      'scroll',
+      event => requestAnimationFrame(() => {
+        const toc = document.querySelector(SELECTORS.thumbsToc);
+        if (!toc) return;
+        const docH = document.body.scrollHeight;
+        const scrollPos = window.scrollY + window.innerHeight;
+        toc.style.display = (scrollPos + SCROLL_HIDE_OFFSET > docH) ? 'none' : 'block';
+      }),
+      { passive: true }
+    );
 
-    feedbackDetails.classList.remove('hidden');
-    form.classList.remove('hidden');
-  });
-});
+    thumbs.forEach(thumb => {
+      thumb.addEventListener('click', () => {
+        positive = thumb.id.includes('up');
+        form.elements['positiveFeedback'].value = positive;
 
-// Fill hidden metadata
-form.addEventListener('submit', () => {
-  const version = "{{{ page.attributes.version }}}" || "";
-  const beta = Boolean({{ is-prerelease page }} || false);
-  const url = window.location.href;
-  const nav = navigator.userAgent + ', ' + navigator.language;
-  const selectedFeedback = form.querySelector('input[name="feedback"]:checked');
+        // Safely build radio options
+        const items = positive
+          ? [ 'Solved my problem', 'Easy to understand', 'Other' ]
+          : [ 'Not helpful', 'Too complex', 'Other' ];
+        options.innerHTML = items.map((txt, i) =>
+          `<label><input type="radio" name="feedback" value="${txt}"${i===0? ' checked':''}> ${txt}</label>`
+        ).join('');
 
+        prompt.textContent = positive
+          ? 'Let us know what we do well:'
+          : 'Let us know what could be improved:';
 
-  if (selectedFeedback) {
-    form.querySelector('input[name="feedback"]').value = selectedFeedback.value;
-  }
-  form.querySelector('input[name="version"]').value = version;
-  form.querySelector('input[name="url"]').value = url;
-  form.querySelector('input[name="positiveFeedback"]').value = positive;
-  form.querySelector('input[name="beta"]').value = beta;
-  form.querySelector('input[name="date"]').value = new Date().toISOString();
-  form.querySelector('input[name="navigator"]').value = nav;
+        details.classList.remove('hidden');
+        form.classList.remove('hidden');
+      });
+    });
 
-  sessionStorage.setItem("feedbackType", positive ? "positive" : "negative");
-});
+    form.addEventListener('submit', () => {
+      const version = form.dataset.version || '';
+      const beta = form.dataset.beta === 'true';
+      form.elements['url'].value = window.location.href;
+      form.elements['positiveFeedback'].value = positive;
+      form.elements['version'].value = version;
+      form.elements['beta'].value = beta;
+      form.elements['date'].value = new Date().toISOString();
+      form.elements['navigator'].value = `${navigator.userAgent}, ${navigator.language}`;
+      // Store feedback type
+      sessionStorage.setItem('feedbackType', positive ? 'positive' : 'negative');
+    });
 
-// Handle cancel/close
-function closeForm(event) {
-  event.preventDefault();
-  form.classList.add("hidden");
-}
+    window.closeForm = event => {
+      event.preventDefault();
+      form.classList.add('hidden');
+    };
 
-window.addEventListener('DOMContentLoaded', () => {
-  const toast = document.getElementById('feedback-toast');
-  const modal = document.getElementById('feedbackForm');
-
-  if (window.location.search.includes('success')) {
-    if (modal) modal.classList.add('hidden');
-    if (toast) {
-      toast.classList.remove('hidden');
-      setTimeout(() => toast.classList.add('hidden'), 5000); // auto-hide after 5s
+    if (submitBtn && hint) {
+      submitBtn.disabled = true;
+      hint.style.display = 'block';
+      const start = Date.now();
+      const intervalId = setInterval(() => {
+        const captcha = document.querySelector(SELECTORS.captchaField);
+        if (captcha && captcha.value.trim() !== '') {
+          submitBtn.disabled = false;
+          hint.style.display = 'none';
+          clearInterval(intervalId);
+        }
+        if (Date.now() - start > POLL_TIMEOUT) {
+          clearInterval(intervalId);
+          console.warn('reCAPTCHA token polling timed out');
+        }
+      }, POLL_INTERVAL);
     }
 
-    // Remove ?success=true from URL without reload
-    const url = new URL(window.location);
-    url.searchParams.delete('success');
-    window.history.replaceState({}, document.title, url.toString());
-  }
-});
+    if (toast && window.location.search.includes('success')) {
+      const modal = document.querySelector(SELECTORS.form);
+      modal.classList.add('hidden');
+      toast.classList.remove('hidden');
+      setTimeout(() => toast.classList.add('hidden'), 5000);
+
+      const url = new URL(window.location.href);
+      url.searchParams.delete('success');
+      window.history.replaceState({}, document.title, url);
+    }
+  });
+})();
 </script>

--- a/src/partials/feedback-form-script.hbs
+++ b/src/partials/feedback-form-script.hbs
@@ -51,7 +51,12 @@ form.addEventListener('submit', () => {
   const beta = {{ is-prerelease page }};
   const url = window.location.href;
   const nav = navigator.userAgent + ', ' + navigator.language;
+  const selectedFeedback = form.querySelector('input[name="feedback"]:checked');
 
+
+  if (selectedFeedback) {
+    form.querySelector('input[name="feedback"]').value = selectedFeedback.value;
+  }
   form.querySelector('input[name="version"]').value = version;
   form.querySelector('input[name="url"]').value = url;
   form.querySelector('input[name="positiveFeedback"]').value = positive;

--- a/src/partials/feedback-form-script.hbs
+++ b/src/partials/feedback-form-script.hbs
@@ -1,77 +1,103 @@
 <script>
+const form = document.getElementById('feedbackForm');
 const thumbs = document.querySelectorAll('.thumb');
-const positiveModal = document.getElementById('positive');
-const negativeModal = document.getElementById('negative');
-var currentForm;
-var positive;
+const feedbackDetails = document.getElementById('feedback-details');
+const feedbackOptions = document.getElementById('feedback-options');
+const feedbackPrompt = document.getElementById('feedback-prompt');
+let positive = null;
 
-thumbs.forEach(function(thumb) {
-  thumb.addEventListener('click', function() {
-    if (thumb.id.indexOf('up') !== -1) {
-      positiveModal.classList.toggle("hidden");
-      currentForm = positiveModal
-      positive = true;
-    } else if (thumb.id.indexOf('down') !== -1) {
-      negativeModal.classList.toggle("hidden");
-      currentForm = negativeModal
-      positive = false;
-    }
+// Scroll visibility toggle for thumbs
+document.addEventListener('scroll', function() {
+  const feedback = document.getElementById('thumbs-toc');
+  if (!feedback) return;
+
+  const modifier = 700;
+  const documentHeight = document.body.scrollHeight;
+  const currentScroll = window.scrollY + window.innerHeight;
+
+  feedback.style.display = (currentScroll + modifier > documentHeight) ? 'none' : 'block';
+});
+
+// Handle thumbs click
+thumbs.forEach(thumb => {
+  thumb.addEventListener('click', () => {
+    positive = thumb.id.includes('up');
+    form.querySelector('input[name="positiveFeedback"]').value = positive;
+
+    feedbackOptions.innerHTML = positive
+      ? `
+        <label><input type="radio" name="feedback" value="Solved my problem" checked> Solved my problem</label>
+        <label><input type="radio" name="feedback" value="Easy to understand"> Easy to understand</label>
+        <label><input type="radio" name="feedback" value="other"> Other</label>
+      `
+      : `
+        <label><input type="radio" name="feedback" value="Not helpful" checked> Not helpful</label>
+        <label><input type="radio" name="feedback" value="Too complex"> Too complex</label>
+        <label><input type="radio" name="feedback" value="other"> Other</label>
+      `;
+
+    feedbackPrompt.textContent = positive
+      ? "Let us know what we do well:"
+      : "Let us know what could be improved:";
+
+    feedbackDetails.classList.remove('hidden');
+    form.classList.remove('hidden');
   });
 });
 
-const handleSubmit = function (event) {
+// Fill hidden metadata
+form.addEventListener('submit', () => {
+  const version = "{{{ page.attributes.version }}}" || "";
+  const beta = {{ is-prerelease page }};
+  const url = window.location.href;
+  const nav = navigator.userAgent + ', ' + navigator.language;
+
+  form.querySelector('input[name="version"]').value = version;
+  form.querySelector('input[name="url"]').value = url;
+  form.querySelector('input[name="positiveFeedback"]').value = positive;
+  form.querySelector('input[name="beta"]').value = beta;
+  form.querySelector('input[name="date"]').value = new Date().toISOString();
+  form.querySelector('input[name="navigator"]').value = nav;
+
+  sessionStorage.setItem("feedbackType", positive ? "positive" : "negative");
+});
+
+// Handle cancel/close
+function closeForm(event) {
   event.preventDefault();
-  const currentUrl = '{{{ or site.url siteRootPath }}}{{{ page.url }}}'
-  const beta = {{ is-prerelease page }}
-  var version = '';
-  {{#if page.attributes.version }}
-  version = {{{ page.attributes.version }}}
-  {{/if}}
-
-  const form = event.target;
-  var formData = new FormData(form);
-
-  formData.set('version', version)
-  formData.set('url', currentUrl)
-  formData.set('positiveFeedback', positive);
-  formData.set('beta', beta)
-
-  const formFields = event.target.closest('form')
-  const feedback = formFields.querySelector('input[name="feedback"]:checked').value
-
-  formData.set('feedback', feedback)
-  formData.set('otherText', (form.querySelector('textarea[name="otherText"]').value))
-
-  formData.set('email', (form.querySelector('input[name="email"]').value))
-
-  formData.set('date', new Date())
-  const nav = window.navigator
-  const navigatorString =
-      nav.userAgent + ', ' + nav.language
-
-  formData.set('navigator', navigatorString)
-
-  fetch("{{page.url}}", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams(formData).toString(),
-  }).then(() => {
-      console.log('Form submission success')
-      clearFeedbackModal()
-    })
-    .catch(error => {
-      console.error('Form submission error:', error)
-    })
+  form.classList.add("hidden");
 }
+
+// Show thank-you modal on redirect
 function clearFeedbackModal() {
-  var modalBody = currentForm.querySelector('.feedback-modal-body');
+  const modalBody = form.querySelector('.feedback-modal-body');
+  const type = sessionStorage.getItem("feedbackType");
+  sessionStorage.removeItem("feedbackType");
+
   modalBody.innerHTML = `
-  {{> feedback-success-modal}}
+    <div class="feedback-success">
+      <h4>🎉 Thank you for your ${type === "positive" ? "positive" : "honest"} feedback!</h4>
+      <p>We appreciate your help improving our documentation.</p>
+      <button type="button" onclick="closeForm(event)">Close</button>
+    </div>
   `;
 }
 
-function closeForm(event) {
-  event.preventDefault()
-  currentForm.classList.toggle("hidden");
-}
+window.addEventListener('DOMContentLoaded', () => {
+  const toast = document.getElementById('feedback-toast');
+  const modal = document.getElementById('feedbackForm');
+
+  if (window.location.search.includes('success')) {
+    if (modal) modal.classList.add('hidden');
+    if (toast) {
+      toast.classList.remove('hidden');
+      setTimeout(() => toast.classList.add('hidden'), 5000); // auto-hide after 5s
+    }
+
+    // Remove ?success=true from URL without reload
+    const url = new URL(window.location);
+    url.searchParams.delete('success');
+    window.history.replaceState({}, document.title, url.toString());
+  }
+});
 </script>

--- a/src/partials/feedback-forms.hbs
+++ b/src/partials/feedback-forms.hbs
@@ -1,5 +1,4 @@
 <form id="feedbackForm" class="hidden" name="feedbackForm" method="POST" netlify-honeypot="bot-field" data-netlify="true" data-netlify-recaptcha="true" action="{{ page.url }}?success=true">
-  <input type="hidden" name="form-name" value="feedbackForm">
 
   <!-- Honeypot -->
   <p class="hidden">

--- a/src/partials/feedback-forms.hbs
+++ b/src/partials/feedback-forms.hbs
@@ -33,8 +33,11 @@
         <div data-netlify-recaptcha="true"></div>
 
         <div class="form-field wrapper">
-          <button type="submit" class="submitButton">Submit</button>
+          <button type="submit" id="submitButton" class="submitButton">Submit</button>
         </div>
+        <p id="captchaHint" class="hint" style="display:none;" aria-describedby="captchaHint" aria-live="polite">
+          Please complete the “I'm not a robot” checkbox to submit.
+        </p>
       </div>
     </div>
   </div>

--- a/src/partials/feedback-forms.hbs
+++ b/src/partials/feedback-forms.hbs
@@ -1,94 +1,44 @@
-<form id="positive" class="hidden" data-netlify-recaptcha="true" data-netlify="true" name="feedbackForm" method="POST" netlify-honeypot="bot-field" onSubmit="handleSubmit(event)">
+<form id="feedbackForm" class="hidden" name="feedbackForm" method="POST" netlify-honeypot="bot-field" data-netlify="true" data-netlify-recaptcha="true" action="{{ page.url }}?success=true">
+  <input type="hidden" name="form-name" value="feedbackForm">
+
+  <!-- Honeypot -->
+  <p class="hidden">
+    <label>Beep-Boop. Bot-field: <input name="bot-field"></label>
+  </p>
+
+  <!-- Hidden metadata -->
+  <input type="hidden" name="version">
+  <input type="hidden" name="url">
+  <input type="hidden" name="positiveFeedback">
+  <input type="hidden" name="beta">
+  <input type="hidden" name="date">
+  <input type="hidden" name="navigator">
+
   <div class="feedback-modal">
     <div class="feedback-modal-body">
-      <h4>What do you like about this doc?</h4>
-      <div>
-        <div class="radio-buttons form-field">
-          <input type="hidden" name="form-name" value="feedbackForm">
-          <p class="hidden">
-            <label class="hidden">Beep-Boop. Bot-field <input name="bot-field"></label>
-          </p>
-          <input class="hidden" name="version">
-          <input class="hidden" name="url">
-          <input class="hidden" name="positiveFeedback">
-          <input class="hidden" name="beta">
-          <input class="hidden" name="date">
-          <input class="hidden" name="navigator">
-          <input class="hidden" name="feedback">
-          <label>
-            <input type="radio" name="feedback" id="solvedProblem" value="Solved my problem" checked="">
-            <span class="radio-label">Solved my problem</span>
-          </label>
-          <label>
-            <input type="radio" name="feedback" id="easyToUnderstand" value="Easy to understand">
-            <span class="radio-label">Easy to understand</span>
-          </label>
-          <label>
-            <input type="radio" name="feedback" id="other" value="other">
-            <span class="radio-label">Other</span>
-          </label>
-        </div>
+      <h4>What do you think of this page?</h4>
+
+      <div id="feedback-details" class="hidden">
+        <div class="radio-buttons form-field" id="feedback-options"></div>
+
         <div class="form-field">
-          <h4>Let us know what we do well:</h4>
-          <textarea id="otherText" name="otherText" rows="4" cols="50" placeholder="Please share details or suggestions for this topic."></textarea>
+          <h4><span id="feedback-prompt">Let us know more:</span></h4>
+          <textarea name="otherText" rows="4" cols="50" placeholder="Please share details or suggestions."></textarea>
         </div>
+
         <div class="form-field">
           <h4>Let us contact you about your feedback:</h4>
-          <input type="text" name="email" id="email" placeholder="email@example.com">
+          <input type="text" name="email" placeholder="email@example.com">
         </div>
+
         <div data-netlify-recaptcha="true"></div>
-      </div>
-      <div class="form-field wrapper">
-        <button type="submit" class="submitButton">Submit</button>
+
+        <div class="form-field wrapper">
+          <button type="submit" class="submitButton">Submit</button>
+        </div>
       </div>
     </div>
   </div>
-  <div class="modal-overlay" id="modal-overlay">
-  </div>
-</form>
-<form id="negative" class="hidden" data-netlify="true" name="feedbackForm" method="POST" netlify-honeypot="bot-field" onSubmit="handleSubmit(event)">
-  <div class="feedback-modal">
-    <div class="feedback-modal-body">
-      <h4>What did you not like about this doc?</h4>
-      <div>
-        <div class="radio-buttons form-field">
-          <input type="hidden" name="form-name" value="feedbackForm">
-          <p class="hidden">
-            <label class="hidden">Beep-Boop. Bot-field <input name="bot-field"></label>
-          </p>
-          <input class="hidden" name="version">
-          <input class="hidden" name="url">
-          <input class="hidden" name="feedback">
-          <input class="hidden" name="beta">
-          <input class="hidden" name="date">
-          <input class="hidden" name="navigator">
-          <label>
-            <input type="radio" name="feedback" id="solvedProblem" value="Did not solve my problem" checked="">
-            <span class="radio-label">Did not solve my problem</span>
-          </label>
-          <label>
-            <input type="radio" name="feedback" id="easyToUnderstand" value="Hard to understand">
-            <span class="radio-label">Hard to understand</span>
-          </label>
-          <label>
-            <input type="radio" name="feedback" id="other" value="other">
-            <span class="radio-label">Other</span>
-          </label>
-        </div>
-        <div class="form-field">
-          <h4>Let us know what we can improve:</h4>
-          <textarea id="otherText" name="otherText" rows="4" cols="50" placeholder="Please share details or suggestions for this topic."></textarea>
-        </div>
-        <div class="form-field">
-          <h4>Let us contact you about your feedback:</h4>
-          <input type="text" name="email" id="email" placeholder="email@example.com">
-        </div>
-      </div>
-      <div class="form-field wrapper">
-        <button type="submit" class="submitButton">Submit</button>
-      </div>
-    </div>
-  </div>
-  <div class="modal-overlay" id="modal-overlay">
-  </div>
+
+  <div class="modal-overlay" id="modal-overlay"></div>
 </form>

--- a/src/partials/feedback-forms.hbs
+++ b/src/partials/feedback-forms.hbs
@@ -1,4 +1,4 @@
-<form id="feedbackForm" class="hidden" name="feedbackForm" method="POST" netlify-honeypot="bot-field" data-netlify="true" data-netlify-recaptcha="true" action="{{ page.url }}?success=true">
+<form id="feedbackForm" class="hidden" name="feedbackForm" method="POST" netlify-honeypot="bot-field" data-netlify="true" data-netlify-recaptcha="true" action="?success=true">
 
   <!-- Honeypot -->
   <p class="hidden">

--- a/src/partials/feedback-success-modal.hbs
+++ b/src/partials/feedback-success-modal.hbs
@@ -1,8 +1,0 @@
-<div class="form-field wrapper">
-  <span class="material-icons MuiIcon-root" aria-hidden="true" style="color: green;overflow: hidden;width: 1em;height: 1em;font-size: 4em;">checkmark</span>
-  <h4>Thank you for your feedback!</h4>
-  <p>We appreciate your input and will use it to improve our documentation.</p>
-  <div class="form-field wrapper">
-    <button onclick="closeForm(event)" class="button close">Close</button>
-  </div>
-</div>

--- a/src/partials/feedback-success.hbs
+++ b/src/partials/feedback-success.hbs
@@ -1,0 +1,3 @@
+<div id="feedback-toast" class="feedback-toast hidden" role="status" aria-live="polite">
+  🎉 Thanks for your feedback!
+</div>

--- a/src/partials/thumbs.hbs
+++ b/src/partials/thumbs.hbs
@@ -9,6 +9,7 @@
     </button>
   </div>
 </div>
+
 <script>
 document.addEventListener('scroll', function(e){
   let documentHeight = document.body.scrollHeight;


### PR DESCRIPTION
This PR updates our feedback form to use native HTML form submission instead of JavaScript `fetch()` to ensure Netlify's built-in reCAPTCHA and spam protection features are actually enforced.

Previously, we submitted the form using `fetch()` to avoid a page reload and keep the modal experience smooth. However, Netlify only applies reCAPTCHA validation and spam filtering to native form POST requests. As a result, our previous approach completely bypassed these protections and allowed spam through, despite reCAPTCHA being enabled in our dashboard.