### PR TITLE
Make the beta badge more visible

### DIFF
--- a/src/css/context-switcher.css
+++ b/src/css/context-switcher.css
@@ -10,6 +10,7 @@
 
 .beta-label {
   margin: 0;
+  font-size: calc(18 / var(--rem-base) * 1rem);
 }
 
 .beta-label > p:hover {
@@ -26,8 +27,9 @@
 .beta-label > p {
   flex: 0 1 auto;
   border-radius: 10px;
+  font-weight: bold;
   text-align: center;
-  border: 1px solid var(--highlight-border);
+  border: 2px solid var(--beta-label-border);
   background-color: inherit;
   color: rgb(102 112 133/1);
 }
@@ -38,6 +40,39 @@
 }
 
 .beta-label > p {
-  color: var(--link-highlight-color);
+  color: var(--beta-label-color);
   padding: 3px;
+  min-width: 100px;
+  margin-top: 5px;
+  background-color: var(--beta-label-background);
+}
+
+.nav-beta-label {
+  display: none;
+  font-size: calc(18 / var(--rem-base) * 1rem);
+  font-weight: bold;
+  min-width: 100px;
+  padding: 3px;
+  border: 2px solid var(--beta-label-border);
+  border-radius: 10px;
+  color: var(--beta-label-color);
+  background-color: var(--beta-label-background);
+  cursor: pointer;
+}
+
+.nav-beta-label.visible {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 0;
+}
+
+.nav-beta-container {
+  position: sticky;
+  top: 0;
+  padding: 0.5rem;
+  padding-bottom: 0;
+  padding-left: 0;
+  background-color: var(--body-background);
+  z-index: 10;
 }

--- a/src/css/context-switcher.css
+++ b/src/css/context-switcher.css
@@ -29,7 +29,6 @@
   border-radius: 10px;
   font-weight: bold;
   text-align: center;
-  border: 2px solid var(--beta-label-border);
   background-color: inherit;
   color: rgb(102 112 133/1);
 }
@@ -53,7 +52,6 @@
   font-weight: bold;
   min-width: 100px;
   padding: 3px;
-  border: 2px solid var(--beta-label-border);
   border-radius: 10px;
   color: var(--beta-label-color);
   background-color: var(--beta-label-background);

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -118,6 +118,9 @@ html[data-theme=dark] {
   --admonition-border-radius: 10px;
   --admonition-box-shadow: 0 1px 2px 0 #0000001a;
   --admonition-padding: 1rem;
+  --beta-label-color: var(--link-highlight-color);
+  --beta-label-background: var(--body-background);
+  --beta-label-border: var(--link-highlight-color);
   /* doc */
   --doc-font-size: inherit;
   --doc-font-size--desktop: var(--body-font-size);

--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -118,9 +118,9 @@ html[data-theme=dark] {
   --admonition-border-radius: 10px;
   --admonition-box-shadow: 0 1px 2px 0 #0000001a;
   --admonition-padding: 1rem;
-  --beta-label-color: var(--link-highlight-color);
-  --beta-label-background: var(--body-background);
-  --beta-label-border: var(--link-highlight-color);
+  --beta-label-color: #fff;
+  --beta-label-background: var(--link-highlight-color);
+  --beta-label-border: var(--slate-800);
   /* doc */
   --doc-font-size: inherit;
   --doc-font-size--desktop: var(--body-font-size);

--- a/src/partials/article.hbs
+++ b/src/partials/article.hbs
@@ -31,15 +31,45 @@
     <p>beta</p>
   </div>
   <script>
-  const betaButton = document.querySelector('.beta-label p');
-  // Create a Tippy instance on the button
-  const tippyInstance = tippy(betaButton, {
-    content: 'This feature is in beta. Features in beta are available for testing and feedback. They are not supported by Redpanda and should not be used in production environments.',
-    animation: 'scale',
-    theme: 'redpanda-term',
-    touch: 'hold',
-    interactive: true,
-    allowHTML: true,
+  document.addEventListener("DOMContentLoaded", () => {
+    const topBadge = document.querySelector(".beta-label p");
+    const navBadge = document.querySelector(".nav-beta-label");
+
+    if (!topBadge || !navBadge) {
+      return;
+    }
+    tippy(navBadge, {
+      content:
+        "This feature is in beta. Features in beta are available for testing and feedback. They are not supported by Redpanda and should not be used in production environments.",
+      animation: "scale",
+      theme: "redpanda-term",
+      touch: "hold",
+      interactive: true,
+      allowHTML: true,
+    });
+    tippy(topBadge, {
+      content:
+        "This feature is in beta. Features in beta are available for testing and feedback. They are not supported by Redpanda and should not be used in production environments.",
+      animation: "scale",
+      theme: "redpanda-term",
+      touch: "hold",
+      interactive: true,
+      allowHTML: true,
+    });
+    const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        navBadge.classList.remove("visible");
+      } else {
+        navBadge.classList.add("visible");
+      }
+    });
+  }, {
+    root: null,
+    threshold: 1.0
+  });
+
+  observer.observe(topBadge);
   });
   </script>
 {{/if}}

--- a/src/partials/toc.hbs
+++ b/src/partials/toc.hbs
@@ -3,6 +3,11 @@
   {{#if (eq page.component.name 'redpanda-labs')}}
     <img src="{{{@root.uiRootPath}}}/img/redpanda-lab-sitting.png" width="150px" height= "150px" alt="Redpanda sitting at a desk mixing chemicals"/>
   {{/if}}
+  {{#if page.attributes.beta}}
+  <div class="nav-beta-container">
+    <p class="nav-beta-label" aria-hidden="true">beta</p>
+  </div>
+  {{/if}}
   <div class="toc-menu"></div>
   <div class="thumbs">
     <ul style="list-style:none">


### PR DESCRIPTION
This pull request introduces enhancements to the styling and behavior of beta labels. The changes improve the visual appearance of beta labels, add dynamic visibility behavior, and enhance user experience with tooltips and sticky navigation.

Before, the beta badge appeared only below the h1, so if a user entered the page halfway down, they wouldn't see it.
To mitigate this issue, this PR adds a feature to make a beta badge appear in the table on contents when you scroll down.

https://github.com/user-attachments/assets/a02e146f-4d64-415e-896c-757e1d5b1d82


### Styling Improvements for Beta Labels:
* [`src/css/context-switcher.css`](diffhunk://#diff-29b8bbc9493d55bb5bdd76d418c0d7e10171c77994c44506609ea96c2910b231R13): Updated `.beta-label` and `.beta-label > p` styles to include bold font weight, adjusted border thickness, and added new properties like `min-width`, `margin-top`, and `background-color`. Introduced `.nav-beta-label` and `.nav-beta-container` classes for sticky navigation and improved display behavior. [[1]](diffhunk://#diff-29b8bbc9493d55bb5bdd76d418c0d7e10171c77994c44506609ea96c2910b231R13) [[2]](diffhunk://#diff-29b8bbc9493d55bb5bdd76d418c0d7e10171c77994c44506609ea96c2910b231R30-R32) [[3]](diffhunk://#diff-29b8bbc9493d55bb5bdd76d418c0d7e10171c77994c44506609ea96c2910b231L41-R77)

### Theme Variable Updates:
* [`src/css/vars.css`](diffhunk://#diff-86b6e2f7ff781aabdfc3dd4c77cc94f553ff0eb266819c7a7ee0f1f7e875a0b3R121-R123): Added new theme variables (`--beta-label-color`, `--beta-label-background`, `--beta-label-border`) to ensure consistent styling of beta labels across light and dark themes.

### Template Enhancements for Beta Labels:
* [`src/partials/article.hbs`](diffhunk://#diff-1e279d84d41d417587384a469aef34dd1338f6fbd631dd1d64f231802c1ca721L34-R73): Replaced the previous tooltip implementation for `.beta-label p` with a more dynamic setup, including intersection observer logic to toggle visibility of `.nav-beta-label` based on scroll position.
* [`src/partials/toc.hbs`](diffhunk://#diff-562f026b8db014d61769b25cf1d55b2a2e96f5a443f1c12f908885ec0a27e121R6-R10): Added a conditional block to display a sticky `.nav-beta-label` container when the page has a `beta` attribute.