### PR TITLE
Update privacy policy link in site footer

### DIFF
--- a/src/partials/footer-content.hbs
+++ b/src/partials/footer-content.hbs
@@ -26,7 +26,7 @@
                 <li class="footer-links-list-item"><a class="footer-links-list-item-detail" aria-label="Pricing" target="_blank" href="https://redpanda.com/contact">Pricing</a></li>
                 <li class="footer-links-list-item"><a class="footer-links-list-item-detail" aria-label="Blog" target="_blank" href="https://redpanda.com/blog">Blog</a></li>
                 <li class="footer-links-list-item"><a class="footer-links-list-item-detail" aria-label="Support" target="_blank" href="https://support.redpanda.com">Support</a></li>
-                <li class="footer-links-list-item"><a class="footer-links-list-item-detail" aria-label="Privacy policy" target="_blank" href="https://redpanda.com/privacy-policy">Privacy policy</a></li>
+                <li class="footer-links-list-item"><a class="footer-links-list-item-detail" aria-label="Privacy policy" target="_blank" href="https://redpanda.com/legal/privacy-policy">Privacy policy</a></li>
                 <li class="footer-links-list-item"><a class="footer-links-list-item-detail" aria-label="Terms of use" target="_blank" href="https://redpanda.com/terms-of-use">Terms of use</a></li>
             </ul>
         </div>


### PR DESCRIPTION
This pull request updates the footer links in the `src/partials/footer-content.hbs` file to reflect a change in the URL structure for the Privacy Policy page.

* Updated the "Privacy policy" link to point to `https://redpanda.com/legal/privacy-policy` instead of `https://redpanda.com/privacy-policy`. (`src/partials/footer-content.hbs`, [src/partials/footer-content.hbsL29-R29](diffhunk://#diff-94f959b9f08a0acf70bbc09fd370de625269834e3b5a6ad922c452a1562c87e9L29-R29))

Closes DOC-1473