### PR TITLE
Update integration ID

### DIFF
--- a/src/partials/home.hbs
+++ b/src/partials/home.hbs
@@ -5,7 +5,7 @@
       <p>For best results, include the name of the product you're interested in as well as the version.</p>
     </div>
     <script>
-      window.UI_INTEGRATION_ID = 'bc719cfb-2fd5-4c76-acde-de9a905f13b3';
+      window.UI_INTEGRATION_ID = '13dd3c3c-52eb-4d92-9b61-383a946bccac';
     </script>
     <div id="kapa-chat-root"></div>
     <script src="{{{uiRootPath}}}/js/AskAI.bundle.js"></script>


### PR DESCRIPTION
Allows us to track users of the home page in the Kapa dashboard independently of the other integrations.