### PR TITLE
Add platform indicator to mobile header for better context visibility

### DIFF
--- a/src/css/header.css
+++ b/src/css/header.css
@@ -1,3 +1,8 @@
+/* Platform indicator for mobile header */
+.platform-indicator-mobile {
+  display: none;
+}
+
 html.is-clipped--navbar {
   overflow-y: hidden;
 }
@@ -251,6 +256,15 @@ html.is-clipped--navbar {
 @media screen and (max-width: 1024px) {
   .navbar-brand {
     height: inherit;
+    align-items: center;
+  }
+
+  .platform-indicator-mobile {
+    display: inline-block;
+    margin-left: 12px;
+    margin-right: 12px;
+    color: #fff;
+    vertical-align: middle;
   }
 
   .header {

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -11,6 +11,7 @@
         <span></span>
         <span></span>
       </button>
+      <span class="platform-indicator-mobile">{{page.component.title}}</span>
     </div>
     <div id="topbar-nav" class="navbar-menu" {{#if isStandaloneWidget}}style="background-color: inherit;"{{else if page.component.latest.asciidoc.attributes.page-header-data}}{{#with page.component.latest.asciidoc.attributes.page-header-data}}style="background-color: {{this.color}}"{{/with}}{{else}}style="background-color: var(--default-header-color)"{{/if}}>
       {{#each (sort-components site.components)}}


### PR DESCRIPTION
This pull request introduces a platform indicator in the mobile header to display the current component's title, along with corresponding CSS for styling and responsive behavior.

<img width="873" height="503" alt="2025-08-14_15-23-22" src="https://github.com/user-attachments/assets/aca4d4c5-f35c-411c-8c5b-f3ddfc6662ff" />

**Feature addition:**

* Added a `span` with the class `platform-indicator-mobile` to the mobile header in `header-content.hbs` to display the current component's title.

**Styling and responsive design:**

* Created a new `.platform-indicator-mobile` CSS class to hide the indicator by default and show it on screens smaller than 1024px, with appropriate styling for alignment and color in `header.css`. [[1]](diffhunk://#diff-180ed83e890e9b5f342b20d343d78676829469602f9e33d044afdf727fce8ceeR1-R5) [[2]](diffhunk://#diff-180ed83e890e9b5f342b20d343d78676829469602f9e33d044afdf727fce8ceeR259-R267)