### PR TITLE
Fix the Algolia search results for the APIs

### DIFF
--- a/src/partials/algolia-script.hbs
+++ b/src/partials/algolia-script.hbs
@@ -1,7 +1,8 @@
-
 <script>
+// Supported previewable types
 const SUPPORTED_PREVIEW_TYPES = ['doc', 'api endpoint'];
 
+// Handlebars-context strings
 const INITIAL_TAG = `
 {{#if (eq page.component.name 'api')}}
 {{{site.components.ROOT.title}}} v{{{site.components.ROOT.latest.version}}}
@@ -11,70 +12,49 @@ const INITIAL_TAG = `
 {{{page.component.title}}} v{{{page.componentVersion.version}}}
 {{else}}
 {{{page.component.title}}}
-{{/if}}`.trim()
+{{/if}}`.trim();
 
-const LATEST_ENTERPRISE = `{{{site.components.ROOT.title}}} v{{{site.components.ROOT.latest.version}}}`.trim()
+const LATEST_ENTERPRISE = `{{{site.components.ROOT.title}}} v{{{site.components.ROOT.latest.version}}}`.trim();
 
 const PRERELEASE = `
 {{#if (and (is-prerelease page) page.displayVersion)}}
 true
 {{else}}
 false
-{{/if}}`.trim()
+{{/if}}`.trim();
 
-var INITIAL_TAGS=['Labs', 'Connect']
+const INITIAL_TAGS = ['Labs', 'Connect'];
 
-const VERSION = PRERELEASE === "true"
+const VERSION = PRERELEASE === 'true'
   ? `{{{page.displayVersion}}}`.trim()
   : `{{{page.componentVersion.version}}}`.trim();
 
-const getVersionDigit = (tag) => {
-    const versionRegex = /v(\d+)/;
-    const match = tag.match(versionRegex);
-    return match ? match[1] : null;
-};
-
-// Get the product name in versioned tags
-// For example Self-Managed v24.2
-const getProductName = (tag) => {
-    const wordBeforeVRegex = /(\S+) v/;
-    const match = tag.match(wordBeforeVRegex);
-    return match ? match[1] : null;
-};
-
+// Merge initial tags with a contextual tag, and dedupe
 const applyFilterTags = (initialTags, initialTag) => {
-  if (!initialTag) return initialTags.map(tag => ({ label: tag, facet: '_tags' }));
-  var mergedTags;
+  if (!initialTag) return initialTags.map((tag) => ({ label: tag, facet: '_tags' }));
+  let mergedTags;
   if (initialTag === 'Home' || initialTag === 'Labs') {
     mergedTags = [...initialTags, 'Cloud', LATEST_ENTERPRISE];
   } else {
     mergedTags = [...initialTags, initialTag];
   }
   mergedTags = [...new Set(mergedTags)];
-  return mergedTags.map(tag => ({ label: tag, facet: '_tags' }));
+  return mergedTags.map((tag) => ({ label: tag, facet: '_tags' }));
 };
 
-// Applies filters to search results
-// https://www.algolia.com/doc-beta/ui-libraries/autocomplete/guides/filtering-results#applying-filters-from-tags
+// Build Algolia tagFilters from tag facets (OR all tags)
 function mapToAlgoliaFilters(tagsByFacet) {
-  let filters = [[]];
-  Object.keys(tagsByFacet).forEach(facet => {
-    tagsByFacet[facet].forEach(tag => {
-      const filterString = tag.label;
-      const isFilterInArray = filters[0].includes(filterString);
-      if (!isFilterInArray) {
-        filters[0].push(filterString);
-      } else {
-        filters[0] = filters[0].filter(item => item !== filterString);
-      }
-    });
-  });
-  return filters;
+  const set = new Set();
+  Object.values(tagsByFacet)
+    .flat()
+    .forEach((tag) => set.add(tag.label));
+  return [Array.from(set)];
 }
+
 function groupBy(items, predicate) {
   return items.reduce((acc, item) => {
     const key = predicate(item);
-    if (!acc.hasOwnProperty(key)) {
+    if (!Object.prototype.hasOwnProperty.call(acc, key)) {
       acc[key] = [];
     }
     acc[key].push(item);
@@ -82,19 +62,30 @@ function groupBy(items, predicate) {
   }, {});
 }
 
-window.addEventListener('DOMContentLoaded', function() {
+window.addEventListener('DOMContentLoaded', function () {
   const { createTagsPlugin } = window['@algolia/autocomplete-plugin-tags'];
-
   const { autocomplete, getAlgoliaResults, getAlgoliaFacets } = window['@algolia/autocomplete-js'];
+  const { createLocalStorageRecentSearchesPlugin } = window['@algolia/autocomplete-plugin-recent-searches'];
+
+  // Ensure Algolia Search Insights is available, then init once
+  window.aa = window.aa || function(){ (window.aa.q = window.aa.q || []).push(arguments); };
+  if (!window.__aaLoaderInserted) {
+    var si = document.createElement('script');
+    si.async = 1;
+    si.src = 'https://cdn.jsdelivr.net/npm/search-insights@2';
+    document.head.appendChild(si);
+    window.__aaLoaderInserted = true;
+  }
+  aa('init', {
+    appId: '{{{env.ALGOLIA_APP_ID}}}',
+    apiKey: '{{{env.ALGOLIA_API_KEY}}}',
+    useCookie: true
+  });
 
   const searchClient = algoliasearch(
     '{{{env.ALGOLIA_APP_ID}}}',
     '{{{env.ALGOLIA_API_KEY}}}'
   );
-
-  const { createLocalStorageRecentSearchesPlugin } = window[
-    '@algolia/autocomplete-plugin-recent-searches'
-  ];
 
   const recentSearchesPlugin = createLocalStorageRecentSearchesPlugin({
     key: 'RECENT_SEARCH',
@@ -103,7 +94,6 @@ window.addEventListener('DOMContentLoaded', function() {
 
   const tagsPlugin = createTagsPlugin({
     // Adds tags on click
-    // See https://www.algolia.com/doc-beta/ui-libraries/autocomplete/guides/filtering-results#adding-tags
     getTagsSubscribers() {
       return [
         {
@@ -124,241 +114,305 @@ window.addEventListener('DOMContentLoaded', function() {
     plugins: [recentSearchesPlugin, tagsPlugin],
     insights: true,
     defaultActiveItemId: 0,
-    onStateChange({ state, setContext }) {
-      if (state.query && !state.context.preview) {
-        const docsCollection = state.collections.find(
-          collection => collection.source.sourceId === 'docs'
-        );
-        if (docsCollection && docsCollection.items.length > 0) {
-          // Set the first result as the preview item.
-          setContext({ preview: docsCollection.items[0] });
-        }
+
+    // Keep preview in sync with the first docs result
+    onStateChange({ state, prevState, setContext }) {
+      const prevQ = prevState?.query ?? '';
+      const nextQ = state.query ?? '';
+
+      // Detect facet/tag changes (labels per facet, order-insensitive)
+      const tagKey = (s) => (s?.context?.tagsPlugin?.tags || [])
+        .map((t) => `${t.facet}:${t.label}`)
+        .sort()
+        .join('|');
+      const prevTagKey = tagKey(prevState);
+      const nextTagKey = tagKey(state);
+      const tagsChanged = prevTagKey !== nextTagKey;
+
+      const docsCollection = state.collections.find((c) => c.source.sourceId === 'docs');
+      const firstHit = docsCollection?.items?.[0] || null;
+
+      // Set preview when query changes or filters change
+      if ((nextQ && nextQ !== prevQ) || tagsChanged) {
+        setContext({ preview: firstHit });
+        return;
+      }
+
+      // Seed preview on initial load if empty
+      if (!state.context.preview && firstHit) {
+        setContext({ preview: firstHit });
       }
     },
-    render({ children, state, render, html, components, createElement }, root) {
+
+    render({ children, state, render, html, components }, root) {
       const { preview } = state.context;
-      if (state.context.preview && !state.context.preview.insightsInitialized) {
-        aa('init',{
-          appId: '{{{env.ALGOLIA_APP_ID}}}',
-          apiKey: '{{{env.ALGOLIA_API_KEY}}}',
-        });
-        state.context.preview.insightsInitialized = true
-      }
       const currentQuery = state.query;
+
+      // Build endpoint example for API Endpoint records
+      const hasEndpoint = !!(preview && (preview.method || preview.path));
+      let endpointLine = '';
+      let curlExample = '';
+      if (hasEndpoint) {
+        const method = (preview.method || 'GET').toUpperCase();
+        const path = preview.path || '';
+        endpointLine = `${method} ${path}`;
+        let origin = '';
+        try { origin = new URL(preview.url || '').origin; } catch (e) { /* no-op */ }
+        curlExample = `curl -X ${method} '${origin ? origin + path : path}'`;
+      }
+
       const askAIButton = currentQuery
-        ? html`<button class="ask-ai" onclick=${() => {window.Kapa.open({ query: currentQuery }); autocompleteInstance.setIsOpen(false)}}>
-      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path fill-rule="evenodd" clip-rule="evenodd" d="M1.01942 4.14696C0.821273 4.07417 0.615365 4.0169 0.403168 3.97662C0.387588 3.97367 0.371975 3.9708 0.356327 3.96802C0.214558 3.94289 0.214558 3.74081 0.356327 3.71568C0.371975 3.7129 0.387588 3.71003 0.403168 3.70709C0.615365 3.6668 0.821273 3.60953 1.01942 3.53675C1.138 3.49318 1.2538 3.44407 1.36651 3.38969C2.14702 3.01321 2.77911 2.38509 3.158 1.60949C3.2127 1.49749 3.26214 1.38242 3.30596 1.26458C3.37921 1.06768 3.43684 0.863067 3.47738 0.652204C3.48035 0.636723 3.48323 0.621208 3.48603 0.605658C3.51132 0.464781 3.71467 0.464781 3.73997 0.605658C3.74277 0.621208 3.74565 0.636723 3.74861 0.652204C3.78916 0.863067 3.84678 1.06768 3.92003 1.26458C3.96387 1.38242 4.01329 1.49749 4.06802 1.60949C4.44688 2.38509 5.07898 3.01321 5.8595 3.38969C5.9722 3.44407 6.088 3.49318 6.20657 3.53675C6.40473 3.60953 6.61063 3.6668 6.82284 3.70709C6.83842 3.71003 6.85402 3.7129 6.86967 3.71568C7.01144 3.74081 7.01144 3.94289 6.86967 3.96802C6.85402 3.9708 6.83842 3.97367 6.82284 3.97662C6.61063 4.0169 6.40473 4.07417 6.20657 4.14696C6.088 4.19052 5.9722 4.23963 5.8595 4.29401C5.07898 4.67049 4.44688 5.29861 4.06802 6.07422C4.01329 6.18622 3.96387 6.30129 3.92003 6.41912C3.84678 6.61602 3.78916 6.82063 3.74861 7.03151C3.74565 7.04697 3.74277 7.06249 3.73997 7.07804C3.71467 7.21893 3.51132 7.21893 3.48603 7.07804C3.48323 7.06249 3.48035 7.04697 3.47738 7.03151C3.43684 6.82063 3.37921 6.61602 3.30596 6.41912C3.26214 6.30129 3.2127 6.18622 3.158 6.07422C2.77911 5.29861 2.14702 4.67049 1.36651 4.29401C1.2538 4.23963 1.138 4.19052 1.01942 4.14696ZM5.75667 9.15294C5.61809 9.11583 5.47758 9.08326 5.3353 9.05541C5.31306 9.05107 5.29079 9.04684 5.26848 9.04271L5.26172 9.04146L5.25257 9.0398C5.23849 9.03725 5.22303 9.03451 5.19212 9.02901L5.18132 9.0271C4.9546 8.98447 4.9546 8.66184 5.18132 8.61921L5.19212 8.6173C5.22303 8.6118 5.23849 8.60906 5.25257 8.60651L5.26172 8.60485L5.26848 8.60361C5.29079 8.59947 5.31306 8.59524 5.33528 8.5909C5.47756 8.56305 5.61809 8.53048 5.75667 8.49337C5.87504 8.46168 5.992 8.42664 6.10746 8.38841C7.9755 7.76963 9.44545 6.30893 10.0681 4.45264C10.1066 4.33791 10.1419 4.22168 10.1738 4.10403C10.2111 3.96634 10.2439 3.8267 10.2719 3.68531C10.2763 3.66323 10.2805 3.6411 10.2847 3.61894L10.286 3.61221L10.2876 3.60312C10.2902 3.5893 10.2929 3.57413 10.2983 3.54409L10.2985 3.54306L10.3004 3.53232C10.3433 3.30702 10.668 3.30702 10.7109 3.53232L10.7128 3.54306C10.7183 3.57377 10.7211 3.58913 10.7237 3.60312L10.7253 3.61221L10.7266 3.61894C10.7307 3.6411 10.735 3.66323 10.7394 3.68531C10.7674 3.82672 10.8002 3.96634 10.8375 4.10403C10.8694 4.22168 10.9047 4.33791 10.9431 4.45264C11.5658 6.30893 13.0358 7.76963 14.9038 8.38841C15.0193 8.42664 15.1362 8.46168 15.2546 8.49337C15.3932 8.53048 15.5337 8.56305 15.676 8.5909C15.6982 8.59524 15.7205 8.59947 15.7428 8.60361L15.7496 8.60485L15.7587 8.60651C15.7728 8.60906 15.7882 8.6118 15.8192 8.6173L15.83 8.61921C16.0567 8.66184 16.0567 8.98447 15.83 9.0271L15.8192 9.02901L15.7864 9.03482L15.7587 9.0398L15.7496 9.04146L15.7428 9.04271C15.7205 9.04684 15.6982 9.05107 15.676 9.05541C15.5337 9.08326 15.3932 9.11583 15.2546 9.15294C15.1362 9.18463 15.0193 9.21967 14.9038 9.2579C13.0358 9.87668 11.5658 11.3374 10.9431 13.1937C10.9047 13.3084 10.8694 13.4246 10.8375 13.5423C10.8002 13.68 10.7674 13.8196 10.7394 13.961C10.735 13.9831 10.7307 14.0052 10.7266 14.0274L10.7253 14.0341L10.7237 14.0432L10.7199 14.0637L10.713 14.1021L10.7109 14.114C10.668 14.3393 10.3433 14.3393 10.3004 14.114L10.2985 14.1033C10.293 14.0726 10.2902 14.0572 10.2876 14.0432L10.286 14.0341L10.2847 14.0274C10.2805 14.0052 10.2763 13.9831 10.2719 13.961C10.2439 13.8196 10.2111 13.68 10.1738 13.5423C10.1419 13.4246 10.1066 13.3084 10.0681 13.1937C9.44545 11.3374 7.9755 9.87668 6.10746 9.2579C5.992 9.21967 5.87504 9.18463 5.75667 9.15294ZM2.63009 13.4745C2.86838 13.5197 3.09411 13.5989 3.30206 13.7067C3.39456 13.7547 3.48354 13.8084 3.56853 13.8673C3.80536 14.0313 4.01129 14.236 4.17642 14.4713C4.23567 14.5558 4.28969 14.6442 4.33796 14.7361C4.44653 14.9428 4.52617 15.1671 4.57168 15.4039C4.57356 15.4137 4.5754 15.4234 4.57715 15.4333C4.59313 15.5222 4.72156 15.5222 4.73754 15.4333C4.7393 15.4234 4.74111 15.4137 4.74299 15.4039C4.78853 15.1671 4.86817 14.9428 4.97672 14.7361C5.02501 14.6442 5.07902 14.5558 5.13828 14.4713C5.30339 14.236 5.50933 14.0313 5.74616 13.8673C5.83115 13.8084 5.92013 13.7547 6.01262 13.7067C6.22059 13.5989 6.44631 13.5197 6.68461 13.4745C6.69445 13.4726 6.7043 13.4708 6.71418 13.469C6.80373 13.4532 6.80373 13.3255 6.71418 13.3097C6.7043 13.3079 6.69445 13.3061 6.68461 13.3042C6.44631 13.259 6.22059 13.1798 6.01262 13.072C5.92013 13.024 5.83115 12.9703 5.74616 12.9114C5.50933 12.7474 5.30339 12.5427 5.13828 12.3074C5.07902 12.2229 5.02501 12.1345 4.97672 12.0426C4.86817 11.836 4.78853 11.6116 4.74299 11.3748C4.74111 11.3651 4.7393 11.3553 4.73754 11.3454C4.72156 11.2565 4.59313 11.2565 4.57715 11.3454C4.5754 11.3553 4.57356 11.3651 4.57168 11.3748C4.52617 11.6116 4.44653 11.836 4.33796 12.0426C4.28969 12.1345 4.23567 12.2229 4.17642 12.3074C4.01129 12.5427 3.80536 12.7474 3.56853 12.9114C3.48354 12.9703 3.39456 13.024 3.30206 13.072C3.09411 13.1798 2.86838 13.259 2.63009 13.3042C2.62025 13.3061 2.61039 13.3079 2.60049 13.3097C2.51097 13.3255 2.51097 13.4532 2.60049 13.469C2.61039 13.4708 2.62025 13.4726 2.63009 13.4745Z" fill="white"/>
-      </svg>
-      Ask AI about "${currentQuery}"
-      </button>`
+        ? html`<button
+            type="button"
+            class="ask-ai"
+            onClick=${() => {
+              if (window.Kapa?.open) {
+                window.Kapa.open({ query: currentQuery });
+                autocompleteInstance.setIsOpen(false);
+              }
+            }}
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M1.01942 4.14696C0.821273 4.07417 0.615365 4.0169 0.403168 3.97662C0.387588 3.97367 0.371975 3.9708 0.356327 3.96802C0.214558 3.94289 0.214558 3.74081 0.356327 3.71568C0.371975 3.7129 0.387588 3.71003 0.403168 3.70709C0.615365 3.6668 0.821273 3.60953 1.01942 3.53675C1.138 3.49318 1.2538 3.44407 1.36651 3.38969C2.14702 3.01321 2.77911 2.38509 3.158 1.60949C3.2127 1.49749 3.26214 1.38242 3.30596 1.26458C3.37921 1.06768 3.43684 0.863067 3.47738 0.652204C3.48035 0.636723 3.48323 0.621208 3.48603 0.605658C3.51132 0.464781 3.71467 0.464781 3.73997 0.605658C3.74277 0.621208 3.74565 0.636723 3.74861 0.652204C3.78916 0.863067 3.84678 1.06768 3.92003 1.26458C3.96387 1.38242 4.01329 1.49749 4.06802 1.60949C4.44688 2.38509 5.07898 3.01321 5.8595 3.38969C5.9722 3.44407 6.088 3.49318 6.20657 3.53675C6.40473 3.60953 6.61063 3.6668 6.82284 3.70709C6.83842 3.71003 6.85402 3.7129 6.86967 3.71568C7.01144 3.74081 7.01144 3.94289 6.86967 3.96802C6.85402 3.9708 6.83842 3.97367 6.82284 3.97662C6.61063 4.0169 6.40473 4.07417 6.20657 4.14696C6.088 4.19052 5.9722 4.23963 5.8595 4.29401C5.07898 4.67049 4.44688 5.29861 4.06802 6.07422C4.01329 6.18622 3.96387 6.30129 3.92003 6.41912C3.84678 6.61602 3.78916 6.82063 3.74861 7.03151C3.74565 7.04697 3.74277 7.06249 3.73997 7.07804C3.71467 7.21893 3.51132 7.21893 3.48603 7.07804C3.48323 7.06249 3.48035 7.04697 3.47738 7.03151C3.43684 6.82063 3.37921 6.61602 3.30596 6.41912C3.26214 6.30129 3.2127 6.18622 3.158 6.07422C2.77911 5.29861 2.14702 4.67049 1.36651 4.29401C1.2538 4.23963 1.138 4.19052 1.01942 4.14696ZM5.75667 9.15294C5.61809 9.11583 5.47758 9.08326 5.3353 9.05541C5.31306 9.05107 5.29079 9.04684 5.26848 9.04271L5.26172 9.04146L5.25257 9.0398C5.23849 9.03725 5.22303 9.03451 5.19212 9.02901L5.18132 9.0271C4.9546 8.98447 4.9546 8.66184 5.18132 8.61921L5.19212 8.6173C5.22303 8.6118 5.23849 8.60906 5.25257 8.60651L5.26172 8.60485L5.26848 8.60361C5.29079 8.59947 5.31306 8.59524 5.33528 8.5909C5.47756 8.56305 5.61809 8.53048 5.75667 8.49337C5.87504 8.46168 5.992 8.42664 6.10746 8.38841C7.9755 7.76963 9.44545 6.30893 10.0681 4.45264C10.1066 4.33791 10.1419 4.22168 10.1738 4.10403C10.2111 3.96634 10.2439 3.8267 10.2719 3.68531C10.2763 3.66323 10.2805 3.6411 10.2847 3.61894L10.286 3.61221L10.2876 3.60312C10.2902 3.5893 10.2929 3.57413 10.2983 3.54409L10.2985 3.54306L10.3004 3.53232C10.3433 3.30702 10.668 3.30702 10.7109 3.53232L10.7128 3.54306C10.7183 3.57377 10.7211 3.58913 10.7237 3.60312L10.7253 3.61221L10.7266 3.61894C10.7307 3.6411 10.735 3.66323 10.7394 3.68531C10.7674 3.82672 10.8002 3.96634 10.8375 4.10403C10.8694 4.22168 10.9047 4.33791 10.9431 4.45264C11.5658 6.30893 13.0358 7.76963 14.9038 8.38841C15.0193 8.42664 15.1362 8.46168 15.2546 8.49337C15.3932 8.53048 15.5337 8.56305 15.676 8.5909C15.6982 8.59524 15.7205 8.59947 15.7428 8.60361L15.7496 8.60485L15.7587 8.60651C15.7728 8.60906 15.7882 8.6118 15.8192 8.6173L15.83 8.61921C16.0567 8.66184 16.0567 8.98447 15.83 9.0271L15.8192 9.02901L15.7864 9.03482L15.7587 9.0398L15.7496 9.04146L15.7428 9.04271C15.7205 9.04684 15.6982 9.05107 15.676 9.05541C15.5337 9.08326 15.3932 9.11583 15.2546 9.15294C15.1362 9.18463 15.0193 9.21967 14.9038 9.2579C13.0358 9.87668 11.5658 11.3374 10.9431 13.1937C10.9047 13.3084 10.8694 13.4246 10.8375 13.5423C10.8002 13.68 10.7674 13.8196 10.7394 13.961C10.735 13.9831 10.7307 14.0052 10.7266 14.0274L10.7253 14.0341L10.7237 14.0432L10.7199 14.0637L10.713 14.1021L10.7109 14.114C10.668 14.3393 10.3433 14.3393 10.3004 14.114L10.2985 14.1033C10.293 14.0726 10.2902 14.0572 10.2876 14.0432L10.286 14.0341L10.2847 14.0274C10.2805 14.0052 10.2763 13.9831 10.2719 13.961C10.2439 13.8196 10.2111 13.68 10.1738 13.5423C10.1419 13.4246 10.1066 13.3084 10.0681 13.1937C9.44545 11.3374 7.9755 9.87668 6.10746 9.2579C5.992 9.21967 5.87504 9.18463 5.75667 9.15294ZM2.63009 13.4745C2.86838 13.5197 3.09411 13.5989 3.30206 13.7067C3.39456 13.7547 3.48354 13.8084 3.56853 13.8673C3.80536 14.0313 4.01129 14.236 4.17642 14.4713C4.23567 14.5558 4.28969 14.6442 4.33796 14.7361C4.44653 14.9428 4.52617 15.1671 4.57168 15.4039C4.57356 15.4137 4.5754 15.4234 4.57715 15.4333C4.59313 15.5222 4.72156 15.5222 4.73754 15.4333C4.7393 15.4234 4.74111 15.4137 4.74299 15.4039C4.78853 15.1671 4.86817 14.9428 4.97672 14.7361C5.02501 14.6442 5.07902 14.5558 5.13828 14.4713C5.30339 14.236 5.50933 14.0313 5.74616 13.8673C5.83115 13.8084 5.92013 13.7547 6.01262 13.7067C6.22059 13.5989 6.44631 13.5197 6.68461 13.4745C6.69445 13.4726 6.7043 13.4708 6.71418 13.469C6.80373 13.4532 6.80373 13.3255 6.71418 13.3097C6.7043 13.3079 6.69445 13.3061 6.68461 13.3042C6.44631 13.259 6.22059 13.1798 6.01262 13.072C5.92013 13.024 5.83115 12.9703 5.74616 12.9114C5.50933 12.7474 5.30339 12.5427 5.13828 12.3074C5.07902 12.2229 5.02501 12.1345 4.97672 12.0426C4.86817 11.836 4.78853 11.6116 4.74299 11.3748C4.74111 11.3651 4.7393 11.3553 4.73754 11.3454C4.72156 11.2565 4.59313 11.2565 4.57715 11.3454C4.5754 11.3553 4.57356 11.3651 4.57168 11.3748C4.52617 11.6116 4.44653 11.836 4.33796 12.0426C4.28969 12.1345 4.23567 12.2229 4.17642 12.3074C4.01129 12.5427 3.80536 12.7474 3.56853 12.9114C3.48354 12.9703 3.39456 13.024 3.30206 13.072C3.09411 13.1798 2.86838 13.259 2.63009 13.3042C2.62025 13.3061 2.61039 13.3079 2.60049 13.3097C2.51097 13.3255 2.51097 13.4532 2.60049 13.469C2.61039 13.4708 2.62025 13.4726 2.63009 13.4745Z"
+                fill="white"
+              />
+            </svg>
+            Ask AI about "${currentQuery}"
+          </button>`
         : '';
+
       const componentTitle = '{{{page.component.title}}}';
-      const productParams = componentTitle === 'Cloud'
-        ? '&product[0]=Cloud&product[1]=Connect'
-      : '&product[0]=Self-Managed&product[1]=Connect';
+      const productParams = (() => {
+        if (componentTitle === 'Cloud') return '&product[0]=Cloud&product[1]=Connect';
+        if (componentTitle === 'Self-Managed') return '&product[0]=Self-Managed&product[1]=Connect';
+        return '';
+      })();
+
       const viewAllLink = currentQuery
-        ? html`<a class="view-all" href="{{{relativize '/search' }}}?q=${encodeURIComponent(currentQuery)}${VERSION ? `&version=${VERSION}` : ''}${productParams}">
+        ? html`<a
+            class="view-all"
+            href="{{{relativize '/search' }}}?q=${encodeURIComponent(currentQuery)}${VERSION ? `&version=${VERSION}` : ''}${productParams}"
+          >
             View all results
           </a>`
         : '';
+
       render(
-        html`<div class="aa-Header">
-            ${askAIButton}
-          </div><div class="aa-Grid">
-        <div class="aa-Results aa-Column--scrollable">${children}</div>
-        ${preview
-          ? html`<div class="aa-Preview aa-Column doc">
-            <div class="aa-PanelLayout aa-Panel--scrollable">
-              ${
-                preview.breadcrumbs
-                ? html`<div class="breadcrumbs">
-                <ul>
-                ${preview.breadcrumbs.map(breadcrumb =>
-                  html`<li><a onclick="${(event) => {
-                    event.stopPropagation();
-                    aa('clickedObjectIDsAfterSearch',{
-                      eventName: 'Preview Selected',
-                      index: state.context.preview.__autocomplete_indexName,
-                      queryID: state.context.preview.__autocomplete_queryID,
-                      objectIDs: [state.context.preview.objectID],
-                      positions: [state.activeItemId + 1] // positions start from 1 but itemIds start from 0
-                    })
-                  }}" href="${breadcrumb.u}">${breadcrumb.t}</a></li>`
-                )}
-                </ul>
-              </div>`
-              : ''
-              }
-              <h3>
-                ${components.Highlight({
-                  hit: preview,
-                  attribute: 'title',
-                })}
-              </h3>
-              <p>
-                ${components.Highlight({
-                  hit: preview,
-                  attribute: 'intro',
-                })}
-              </p>
-              ${
-                preview.image
-                ? html`<div class="aa-ItemIcon">
-                      ${SUPPORTED_PREVIEW_TYPES.includes((preview.type || '').toLowerCase()) ?
-                        html`<a
-                          onclick="${(event) => {
-                          event.stopPropagation();
-                          aa('clickedObjectIDsAfterSearch',{
-                            eventName: 'Preview Selected',
-                            index: state.context.preview.__autocomplete_indexName,
-                            queryID: state.context.preview.__autocomplete_queryID,
-                            objectIDs: [state.context.preview.objectID],
-                            positions: [state.activeItemId + 1] // positions start from 1 but itemIds start from 0
-                          })
-                        }}" href="${preview.objectID}"><img
-                            src="${preview.image}"
-                          /></a>` :
-                        html`<a
-                          onclick="${(event) => {
-                          event.stopPropagation();
-                          aa('clickedObjectIDsAfterSearch',{
-                            eventName: 'Preview Selected',
-                            index: state.context.preview.__autocomplete_indexName,
-                            queryID: state.context.preview.__autocomplete_queryID,
-                            objectIDs: [state.context.preview.objectID],
-                            positions: [state.activeItemId + 1] // positions start from 1 but itemIds start from 0
-                          })
-                        }}" target="_blank" href="${preview.objectID}"><img
-                            src="${preview.image}"/>
-                        </a>`
+        html`<div class="aa-Header">${askAIButton}</div>
+          <div class="aa-Grid">
+            <div class="aa-Results aa-Column--scrollable">${children}</div>
+            ${
+              preview
+                ? html`<div class="aa-Preview aa-Column doc">
+                    <div class="aa-PanelLayout aa-Panel--scrollable">
+                      ${
+                        preview.breadcrumbs
+                          ? html`<div class="breadcrumbs">
+                              <ul>
+                                ${preview.breadcrumbs.map(
+                                  (breadcrumb) =>
+                                    html`<li>
+                                      <a
+                                        onClick=${(event) => {
+                                          event.stopPropagation();
+                                          aa('clickedObjectIDsAfterSearch', {
+                                            eventName: 'Preview Selected',
+                                            index: state.context.preview.__autocomplete_indexName,
+                                            queryID: state.context.preview.__autocomplete_queryID,
+                                            objectIDs: [state.context.preview.objectID],
+                                            positions: [state.activeItemId + 1], // positions start from 1
+                                          });
+                                        }}
+                                        href="${breadcrumb.u}"
+                                      >
+                                        ${breadcrumb.t}
+                                      </a>
+                                    </li>`
+                                )}
+                              </ul>
+                            </div>`
+                          : ''
                       }
-                      </div>`
+                      <h3>
+                        ${components.Highlight({
+                          hit: preview,
+                          attribute: 'title',
+                        })}
+                      </h3>
+                      <p>${ preview.intro ? components.Highlight({ hit: preview, attribute: 'intro' }) : preview.description ? components.Highlight({ hit: preview, attribute: 'description' }) : '' }</p>
+                      ${ hasEndpoint ? html`<div class="endpoint-example">
+                          <h4>Endpoint</h4>
+                          <pre><code>${endpointLine}</code></pre>
+                          <h4>Example</h4>
+                          <pre><code>${curlExample}</code></pre>
+                        </div>` : '' }
+                      ${
+                        preview.image
+                          ? html`<div class="aa-ItemIcon">
+                              ${
+                                SUPPORTED_PREVIEW_TYPES.includes((preview.type || '').toLowerCase())
+                                  ? html`<a
+                                      onClick=${(event) => {
+                                        event.stopPropagation();
+                                        aa('clickedObjectIDsAfterSearch', {
+                                          eventName: 'Preview Selected',
+                                          index: state.context.preview.__autocomplete_indexName,
+                                          queryID: state.context.preview.__autocomplete_queryID,
+                                          objectIDs: [state.context.preview.objectID],
+                                          positions: [state.activeItemId + 1],
+                                        });
+                                      }}
+                                      href="${preview.url || preview.objectID}"
+                                    >
+                                      <img src="${preview.image}" alt="${preview.title || ''}" />
+                                    </a>`
+                                  : html`<a
+                                      onClick=${(event) => {
+                                        event.stopPropagation();
+                                        aa('clickedObjectIDsAfterSearch', {
+                                          eventName: 'Preview Selected',
+                                          index: state.context.preview.__autocomplete_indexName,
+                                          queryID: state.context.preview.__autocomplete_queryID,
+                                          objectIDs: [state.context.preview.objectID],
+                                          positions: [state.activeItemId + 1],
+                                        });
+                                      }}
+                                      target="_blank"
+                                      href="${preview.url || preview.objectID}"
+                                    >
+                                      <img src="${preview.image}" alt="${preview.title || ''}" />
+                                    </a>`
+                              }
+                            </div>`
+                          : ''
+                      }
+                      <div class="toc sidebar">
+                        <div class="toc-menu">
+                          ${preview.titles && preview.titles.length > 0 ? html`<h4>On this page</h4>` : ''}
+                          <ul>
+                            ${
+                              (preview.titles || []).slice(0, 15).map(
+                                (title) => html`<li>
+                                  ${
+                                    SUPPORTED_PREVIEW_TYPES.includes((state.context.preview.type || '').toLowerCase())
+                                      ? html`<a
+                                          onClick=${(event) => {
+                                            event.stopPropagation();
+                                            aa('clickedObjectIDsAfterSearch', {
+                                              eventName: 'Preview Selected',
+                                              index: state.context.preview.__autocomplete_indexName,
+                                              queryID: state.context.preview.__autocomplete_queryID,
+                                              objectIDs: [state.context.preview.objectID],
+                                              positions: [state.activeItemId + 1],
+                                            });
+                                          }}
+                                          href="${(preview.url || preview.objectID)}#${title.h}"
+                                        >
+                                          ${components.Highlight({ hit: title, attribute: 't' })}
+                                        </a>`
+                                      : html`<a
+                                          onClick=${(event) => {
+                                            event.stopPropagation();
+                                            aa('clickedObjectIDsAfterSearch', {
+                                              eventName: 'Preview Selected',
+                                              index: state.context.preview.__autocomplete_indexName,
+                                              queryID: state.context.preview.__autocomplete_queryID,
+                                              objectIDs: [state.context.preview.objectID],
+                                              positions: [state.activeItemId + 1],
+                                            });
+                                          }}
+                                          target="_blank"
+                                          href="${(preview.url || preview.objectID)}#${title.h}"
+                                        >
+                                          ${components.Highlight({ hit: title, attribute: 't' })}
+                                        </a>`
+                                  }
+                                </li>`
+                              )
+                            }
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <footer class="search-footer">
+                    <ul class="search-commands">
+                      <li>
+                        <kbd class="algolia-command" aria-label="Enter to select">
+                          <svg width="15" height="15" aria-label="Enter key" role="img">
+                            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.2">
+                              <path d="M12 3.53088v3c0 1-1 2-2 2H4M7 11.53088l-3-3 3-3"></path>
+                            </g>
+                          </svg>
+                        </kbd>
+                        <span class="algolia-label">to select</span>
+                      </li>
+                      <li>
+                        <kbd class="algolia-command">
+                          <svg width="15" height="15" aria-label="Arrow down" role="img">
+                            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.2">
+                              <path d="M7.5 3.5v8M10.5 8.5l-3 3-3-3"></path>
+                            </g>
+                          </svg>
+                        </kbd>
+                        <kbd class="algolia-command">
+                          <svg width="15" height="15" aria-label="Arrow up" role="img">
+                            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.2">
+                              <path d="M7.5 11.5v-8M10.5 6.5l-3-3-3 3"></path>
+                            </g>
+                          </svg>
+                        </kbd>
+                        <span class="algolia-label">to navigate</span>
+                      </li>
+                      <li>
+                        <kbd class="algolia-command">
+                          <svg width="15" height="15" aria-label="Escape key" role="img">
+                            <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.2">
+                              <path d="M13.6167 8.936c-.1065.3583-.6883.962-1.4875.962-.7993 0-1.653-.9165-1.653-2.1258v-.5678c0-1.2548.7896-2.1016 1.653-2.1016.8634 0 1.3601.4778 1.4875 1.0724M9 6c-.1352-.4735-.7506-.9219-1.46-.8972-.7092.0246-1.344.57-1.344 1.2166s.4198.8812 1.3445.9805C8.465 7.3992 8.968 7.9337 9 8.5c.032.5663-.454 1.398-1.4595 1.398C6.6593 9.898 6 9 5.963 8.4851m-1.4748.5368c-.2635.5941-.8099.876-1.5443.876s-1.7073-.6248-1.7073-2.204v-.4603c0-1.0416.721-2.131 1.7073-2.131.9864 0 1.6425 1.031 1.5443 2.2492h-2.956"></path>
+                            </g>
+                          </svg>
+                        </kbd>
+                        <span class="algolia-label">to close</span>
+                      </li>
+                    </ul>
+                    ${viewAllLink}
+                  </footer>`
                 : ''
-              }
-              <div class="toc sidebar">
-                <div class="toc-menu">
-                  ${preview.titles && preview.titles.length > 0 ?
-                  html`<h4>On this page</h4>`
-                  : ''}
-                  <ul>
-                  ${preview.titles && preview.titles.length > 0 && preview.titles.map(title =>
-                    html`<li>
-                      ${SUPPORTED_PREVIEW_TYPES.includes((state.context.preview.type || '').toLowerCase()) ?
-                        html`<a onclick="${(event) => {
-                          event.stopPropagation();
-                          aa('clickedObjectIDsAfterSearch',{
-                            eventName: 'Preview Selected',
-                            index: state.context.preview.__autocomplete_indexName,
-                            queryID: state.context.preview.__autocomplete_queryID,
-                            objectIDs: [state.context.preview.objectID],
-                            positions: [state.activeItemId + 1] // positions start from 1 but itemIds start from 0
-                          })
-                        }}" href="${preview.objectID}#${title.h}">${components.Highlight({
-                              hit: title,
-                              attribute: 't',
-                          })}</a>` :
-                        html`<a onclick="${(event) => {
-                          event.stopPropagation();
-                          aa('clickedObjectIDsAfterSearch',{
-                            eventName: 'Preview Selected',
-                            index: state.context.preview.__autocomplete_indexName,
-                            queryID: state.context.preview.__autocomplete_queryID,
-                            objectIDs: [state.context.preview.objectID],
-                            positions: [state.activeItemId + 1] // positions start from 1 but itemIds start from 0
-                          })
-                        }}" target="_blank" href="${preview.objectID}#${title.h}">${components.Highlight({
-                              hit: title,
-                              attribute: 't',
-                          })}</a>`
-                        }
-                    </li>`
-                  )}
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </div>
-          <footer class="search-footer">
-            <ul class="search-commands">
-              <li>
-                <kbd class="algolia-command">
-                  <svg width="15" height="15" aria-label="Enter key" role="img">
-                    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.2">
-                      <path d="M12 3.53088v3c0 1-1 2-2 2H4M7 11.53088l-3-3 3-3"></path>
-                    </g>
-                  </svg>
-                </kbd>
-                <span class="algolia-label">to select</span>
-              </li>
-              <li>
-                <kbd class="algolia-command">
-                  <svg width="15" height="15" aria-label="Arrow down" role="img">
-                    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.2">
-                      <path d="M7.5 3.5v8M10.5 8.5l-3 3-3-3"></path>
-                    </g>
-                  </svg>
-                </kbd>
-                <kbd class="algolia-command">
-                  <svg width="15" height="15" aria-label="Arrow up" role="img">
-                    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.2">
-                      <path d="M7.5 11.5v-8M10.5 6.5l-3-3-3 3"></path>
-                    </g>
-                  </svg>
-                </kbd>
-                <span class="algolia-label">to navigate</span>
-              </li>
-              <li>
-                <kbd class="algolia-command">
-                  <svg width="15" height="15" aria-label="Escape key" role="img">
-                    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.2">
-                      <path d="M13.6167 8.936c-.1065.3583-.6883.962-1.4875.962-.7993 0-1.653-.9165-1.653-2.1258v-.5678c0-1.2548.7896-2.1016 1.653-2.1016.8634 0 1.3601.4778 1.4875 1.0724M9 6c-.1352-.4735-.7506-.9219-1.46-.8972-.7092.0246-1.344.57-1.344 1.2166s.4198.8812 1.3445.9805C8.465 7.3992 8.968 7.9337 9 8.5c.032.5663-.454 1.398-1.4595 1.398C6.6593 9.898 6 9 5.963 8.4851m-1.4748.5368c-.2635.5941-.8099.876-1.5443.876s-1.7073-.6248-1.7073-2.204v-.4603c0-1.0416.721-2.131 1.7073-2.131.9864 0 1.6425 1.031 1.5443 2.2492h-2.956"></path>
-                    </g>
-                  </svg>
-                </kbd>
-                <span class="algolia-label">to close</span>
-              </li>
-            </ul>
-            ${viewAllLink}
-          </footer>`
-          : ''
-          }
-        </div>`,
+            }
+          </div>`,
         root
       );
     },
+
     getSources({ query, state }) {
-      const tagsByFacet = groupBy(
-        state.context.tagsPlugin.tags,
-        (tag) => tag.facet
-      );
+      const tagsByFacet = groupBy(state.context.tagsPlugin.tags, (tag) => tag.facet);
       return [
         {
           sourceId: 'filters',
-          getItems({ query }) {
+          getItems() {
             return getAlgoliaFacets({
               searchClient,
               queries: [
-              {
-                indexName: '{{{env.ALGOLIA_INDEX_NAME}}}',
-                facet: '_tags',
-                params: {
-                  facetQuery: '',
+                {
+                  indexName: '{{{env.ALGOLIA_INDEX_NAME}}}',
+                  facet: '_tags',
+                  params: {
+                    facetQuery: '',
+                  },
                 },
-              },
-            ],
-            // Removes filters from the list after they've been applied
-            // to prevent confusion where a filter is applied but can still be clicked
-            transformResponse({ facetHits }) {
-              const existingTags = (tagsByFacet["_tags"] || []).map(tag => tag.label);
+              ],
+              // Remove filters once applied so users can't re-add the same tag
+              transformResponse({ facetHits }) {
+                const existingTags = (tagsByFacet['_tags'] || []).map((tag) => tag.label);
 
-              return facetHits[0]
-                .filter(hit =>
-                  !existingTags.includes(hit.label)
-                )
-                .map(hit => ({ ...hit, facet: '_tags' }));
-            },
-          });
+                return facetHits[0]
+                  .filter((hit) => !existingTags.includes(hit.label))
+                  .map((hit) => ({ ...hit, facet: '_tags' }));
+              },
+            });
           },
           templates: {
             item({ item, components, html }) {
@@ -372,14 +426,11 @@ window.addEventListener('DOMContentLoaded', function() {
                 </div>
               </div>`;
             },
-            header({items, html}) {
-              if (!items.length) {
-                return;
-              }
-              let headerTitle = "Add filters";
+            header({ items, html }) {
+              if (!items.length) return;
               return html`
-              <span class="aa-SourceHeaderTitle">${headerTitle}</span>
-              <div class="aa-SourceHeaderLine"></div>`;
+                <span class="aa-SourceHeaderTitle">Add filters</span>
+                <div class="aa-SourceHeaderLine"></div>`;
             },
           },
         },
@@ -402,20 +453,25 @@ window.addEventListener('DOMContentLoaded', function() {
                 },
               ],
               transformResponse({ hits }) {
-                return hits.map(nestedHits => {
+                return hits.map((nestedHits) => {
                   const docIndices = new Map();
                   nestedHits.forEach((item, index) => {
                     if (item.type === 'Doc') {
                       docIndices.set(index, item);
                     }
                   });
-                  const nonDocItems = nestedHits.filter(item => item.type !== 'Doc' && typeof item.unixTimestamp === 'number')
-                    .sort((a, b) => b.unixTimestamp - a.unixTimestamp);
+
+                  const nonDocItems = nestedHits
+                    .filter((item) => item.type !== 'Doc')
+                    .sort((a, b) => (b.unixTimestamp ?? -Infinity) - (a.unixTimestamp ?? -Infinity));
+
                   let nonDocIndex = 0;
 
                   docIndices.forEach((item, index) => {
                     if (item._highlightResult && item._highlightResult.titles) {
-                      const matchedIndex = item._highlightResult.titles.findIndex(title => title.t.matchLevel === "full");
+                      const matchedIndex = item._highlightResult.titles.findIndex(
+                        (title) => title.t.matchLevel === 'full'
+                      );
                       if (matchedIndex !== -1) {
                         const matchedTopLevelTitle = item.titles[matchedIndex];
                         if (matchedTopLevelTitle) {
@@ -426,166 +482,126 @@ window.addEventListener('DOMContentLoaded', function() {
                     nestedHits[index] = item;
                   });
 
-                  return nestedHits.map((item, index) => {
-                    return docIndices.has(index) ? docIndices.get(index) : nonDocItems[nonDocIndex++];
-                  });
+                  return nestedHits.map((item, index) =>
+                    docIndices.has(index) ? docIndices.get(index) : nonDocItems[nonDocIndex++]
+                  );
                 });
               },
-            })
+            });
           },
           templates: {
-            noResults({state, html}) {
-              state.context.preview = null
-              if (!state.query) return
+            noResults({ state, html }) {
+              state.context.preview = null;
+              if (!state.query) return;
               return html`
-              <div>No results for ${state.query}</div><p>Believe this query should return results?<a target="_blank" href="https://github.com/redpanda-data/documentation/issues/new?title=No%20search%20results%20for%20${state.query}"> Let us know</a>.</p>`;
+                <div>No results for ${state.query}</div>
+                <p>
+                  Believe this query should return results?
+                  <a target="_blank" href="https://github.com/redpanda-data/documentation/issues/new?title=No%20search%20results%20for%20${state.query}">
+                    Let us know
+                  </a>.
+                </p>`;
             },
-            header({items, html}) {
-              if (!items.length) {
-                return;
-              }
-
+            header({ items, html }) {
+              if (!items.length) return;
               return html`
-              <span class="aa-SourceHeaderTitle">Results</span>
-              <div class="aa-SourceHeaderLine"></div>`;
+                <span class="aa-SourceHeaderTitle">Results</span>
+                <div class="aa-SourceHeaderLine"></div>`;
             },
             item({ item, components, html }) {
-              const matchingHeading = item.matchingHeading || ''
-              const aTag = SUPPORTED_PREVIEW_TYPES.includes((item.type || '').toLowerCase()) ? html`<a class="aa-ItemLink" href="${item.objectID}${matchingHeading}">
-                <div class="aa-ItemContent">
-                  <div class="aa-ItemContentBody">
-                    <div class="aa-ItemContentRow">
-                      <div class="aa-ItemContentTitle">
-                        ${components.Highlight({
-                          hit: item,
-                          attribute: 'title',
-                        })}
+              const matchingHeading = item.matchingHeading || '';
+              const aTag = SUPPORTED_PREVIEW_TYPES.includes((item.type || '').toLowerCase())
+                ? html`<a class="aa-ItemLink" href="${item.url || item.objectID}${matchingHeading}">
+                    <div class="aa-ItemContent">
+                      <div class="aa-ItemContentBody">
+                        <div class="aa-ItemContentRow">
+                          <div class="aa-ItemContentTitle">
+                            ${components.Highlight({ hit: item, attribute: 'title' })}
+                          </div>
+                        </div>
+                        ${
+                          item.text
+                            ? html`<div class=\"aa-ItemContentSnippet\">${ item.text ? components.Snippet({ hit: item, attribute: 'text' }) : item.intro ? components.Snippet({ hit: item, attribute: 'intro' }) : item.description ? components.Snippet({ hit: item, attribute: 'description' }) : '' }</div>`
+                            : html`<div class=\"aa-ItemContentSnippet\">${ item.intro ? components.Snippet({ hit: item, attribute: 'intro' }) : item.description ? components.Snippet({ hit: item, attribute: 'description' }) : '' }</div>`
+                        }
+                        <div class="aa-ItemContentRow">
+                          <div class="aa-ItemContentTitle result-type">${item.type}</div>
+                          ${item.product ? html`<div class="aa-ItemContentTitle result-type">${item.product}</div>` : ''}
+                          ${item.version ? html`<div class="aa-ItemContentTitle result-type">${item.version}</div>` : ''}
+                        </div>
+                      </div>
+                      <div class="aa-ItemActions">
+                        <button
+                          class="aa-ItemActionButton aa-DesktopOnly aa-ActiveOnly"
+                          type="button"
+                          aria-label="Open page"
+                          title="Open page"
+                        >
+                          <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+                            <path d="M18.984 6.984h2.016v6h-15.188l3.609 3.609-1.406 1.406-6-6 6-6 1.406 1.406-3.609 3.609h13.172v-4.031z" />
+                          </svg>
+                        </button>
                       </div>
                     </div>
-                    ${ item.text
-                    ? html`<div class="aa-ItemContentSnippet">
-                      ${components.Snippet({
-                        hit: item,
-                        attribute: 'text',
-                      })}
-                    </div>`
-                    : html`<div class="aa-ItemContentSnippet">
-                      ${components.Snippet({
-                        hit: item,
-                        attribute: 'intro',
-                      })}
-                    </div>`
-                    }
-                    <div class="aa-ItemContentRow">
-                      <div class="aa-ItemContentTitle result-type">
-                        ${item.type}
+                  </a>`
+                : html`<a target="_blank" class="aa-ItemLink" href="${item.url || item.objectID}">
+                    <div class="aa-ItemContent">
+                      <div class="aa-ItemContentBody">
+                        <div class="aa-ItemContentRow">
+                          <div class="aa-ItemContentTitle">
+                            ${components.Highlight({ hit: item, attribute: 'title' })}
+                          </div>
+                        </div>
+                        ${
+                          item.breadcrumbs
+                            ? html`<div class="aa-ItemContentRow">
+                                <div class="aa-Breadcrumbs">
+                                  <ul>
+                                    ${
+                                      item.breadcrumbs.length > 2 &&
+                                      item.breadcrumbs
+                                        .slice(1, item.breadcrumbs.length - 1)
+                                        .map((breadcrumb) => html`<li>${breadcrumb.t}</li>`)
+                                    }
+                                    ${
+                                      item.breadcrumbs.length === 2 &&
+                                      item.breadcrumbs.slice(1).map((breadcrumb) => html`<li>${breadcrumb.t}</li>`)
+                                    }
+                                  </ul>
+                                </div>
+                              </div>`
+                            : ''
+                        }
+                        <div class=\"aa-ItemContentSnippet\">${ item.text ? components.Snippet({ hit: item, attribute: 'text' }) : item.intro ? components.Snippet({ hit: item, attribute: 'intro' }) : item.description ? components.Snippet({ hit: item, attribute: 'description' }) : '' }</div>
+                        <div class="aa-ItemContentRow">
+                          <div class="aa-ItemContentTitle result-type">${item.type}</div>
+                          ${item.version ? html`<div class="aa-ItemContentTitle result-type">${item.version}</div>` : ''}
+                        </div>
                       </div>
-                      ${item.product ? html`
-                      <div class="aa-ItemContentTitle result-type">
-                        ${item.product}
-                      </div>` : ''
-                      }
-                      ${item.version ? html`
-                      <div class="aa-ItemContentTitle result-type">
-                        ${item.version}
-                      </div>` : ''
-                      }
-                    </div>
-                  </div>
-                  <div class="aa-ItemActions">
-                    <button
-                      class="aa-ItemActionButton aa-DesktopOnly aa-ActiveOnly"
-                      type="button"
-                      title="Open page"
-                    >
-                      <svg
-                        viewBox="0 0 24 24"
-                        width="20"
-                        height="20"
-                        fill="currentColor"
-                      >
-                        <path
-                          d="M18.984 6.984h2.016v6h-15.188l3.609 3.609-1.406 1.406-6-6 6-6 1.406 1.406-3.609 3.609h13.172v-4.031z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-              </a>` : html`<a target="_blank" class="aa-ItemLink" href="${item.objectID}">
-                <div class="aa-ItemContent">
-                  <div class="aa-ItemContentBody">
-                    <div class="aa-ItemContentRow">
-                      <div class="aa-ItemContentTitle">
-                        ${components.Highlight({
-                          hit: item,
-                          attribute: 'title',
-                        })}
+                      <div class="aa-ItemActions">
+                        <button
+                          class="aa-ItemActionButton aa-DesktopOnly aa-ActiveOnly"
+                          type="button"
+                          aria-label="Open page"
+                          title="Open page"
+                        >
+                          <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor">
+                            <path d="M18.984 6.984h2.016v6h-15.188l3.609 3.609-1.406 1.406-6-6 6-6 1.406 1.406-3.609 3.609h13.172v-4.031z" />
+                          </svg>
+                        </button>
                       </div>
                     </div>
-                    ${ item.breadcrumbs
-                      ? html`<div class="aa-ItemContentRow">
-                      <div class="aa-Breadcrumbs">
-                        <ul>
-                        ${item.breadcrumbs.length > 2 && item.breadcrumbs.slice(1, item.breadcrumbs.length - 1).map(breadcrumb =>
-                        html`<li>${breadcrumb.t}</li>`
-                        )}
-                        ${item.breadcrumbs.length === 2 && item.breadcrumbs.slice(1).map(breadcrumb =>
-                        html`<li>${breadcrumb.t}</li>`
-                        )}
-                        </ul>
-                      </div>
-                    </div>`
-                    : ''
-                  }
-                    <div class="aa-ItemContentSnippet">
-                      ${components.Snippet({
-                        hit: item,
-                        attribute: 'text',
-                      })}
-                    </div>
-                    <div class="aa-ItemContentRow">
-                      <div class="aa-ItemContentTitle result-type">
-                        ${item.type}
-                      </div>
-                      ${item.version ? html`
-                      <div class="aa-ItemContentTitle result-type">
-                        ${item.version}
-                      </div>` : ''
-                      }
-                    </div>
-                  </div>
-                  <div class="aa-ItemActions">
-                    <button
-                      class="aa-ItemActionButton aa-DesktopOnly aa-ActiveOnly"
-                      type="button"
-                      title="Open page"
-                    >
-                      <svg
-                        viewBox="0 0 24 24"
-                        width="20"
-                        height="20"
-                        fill="currentColor"
-                      >
-                        <path
-                          d="M18.984 6.984h2.016v6h-15.188l3.609 3.609-1.406 1.406-6-6 6-6 1.406 1.406-3.609 3.609h13.172v-4.031z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-              </a>`
+                  </a>`;
               return html`${aTag}`;
             },
           },
-          getItemUrl({ item }) {
-            return item.objectID;
-          },
+          getItemUrl({ item }) { return item.url || item.objectID; },
           onActive({ item, setContext }) {
             setContext({ preview: item });
           },
-        }
+        },
       ];
     },
   });
-})
+});
 </script>


### PR DESCRIPTION
Previously, API search results always appeared empty because we expected a unixtimestamp field.

Now the results are properly displayed (I will add an improvement to our indexer to clarify which API the endpoint is for).

<img width="1198" height="797" alt="2025-08-21_08-18-23" src="https://github.com/user-attachments/assets/cad0f349-e8c3-42e9-a4bf-171723c30683" />


