### PR TITLE
Fix bump styles

### DIFF
--- a/src/css/search-bump.css
+++ b/src/css/search-bump.css
@@ -1,3 +1,34 @@
+:root {
+  --body-font-color: #181818;
+  --body-background: var(--color-white);
+  --doc-font-size: inherit;
+  --doc-line-height: 1.6;
+  --heading-font-color: #101828;
+  --heading-font-family: "Inter", sans-serif;
+  --heading-font-weight: 500;
+  --rem-base: 18;
+  --abstract-background: #f0f0f0;
+  --alt-heading-font-weight: bold;
+  --color-aliases-static-palette-text-tertiary: #6b7280;
+  --aa-detached-modal-max-width: 1200px;
+  --link-highlight-color: #444ce7;
+}
+
+html[data-theme=dark] {
+  --body-font-color: #f2f4f7;
+  --body-background: #101828;
+  --doc-font-size: inherit;
+  --doc-line-height: 1.6;
+  --heading-font-color: #eaecf0;
+  --heading-font-family: "Inter", sans-serif;
+  --heading-font-weight: 500;
+  --rem-base: 18;
+  --abstract-background: #292929;
+  --alt-heading-font-weight: bold;
+  --color-aliases-static-palette-text-tertiary: #98a2b3;
+  --link-highlight-color: #9184f1;
+}
+
 .aa-Source[data-autocomplete-source-id="filters"] .aa-List .aa-Item:empty {
   display: none !important;
 }

--- a/src/css/search-bump.css
+++ b/src/css/search-bump.css
@@ -1,34 +1,3 @@
-:root {
-  --body-font-color: #181818;
-  --body-background: var(--color-white);
-  --doc-font-size: inherit;
-  --doc-line-height: 1.6;
-  --heading-font-color: #101828;
-  --heading-font-family: "Inter", sans-serif;
-  --heading-font-weight: 500;
-  --rem-base: 18;
-  --abstract-background: #f0f0f0;
-  --alt-heading-font-weight: bold;
-  --color-aliases-static-palette-text-tertiary: #6b7280;
-  --aa-detached-modal-max-width: 1200px;
-  --link-highlight-color: #444ce7;
-}
-
-html[data-theme=dark] {
-  --body-font-color: #f2f4f7;
-  --body-background: #101828;
-  --doc-font-size: inherit;
-  --doc-line-height: 1.6;
-  --heading-font-color: #eaecf0;
-  --heading-font-family: "Inter", sans-serif;
-  --heading-font-weight: 500;
-  --rem-base: 18;
-  --abstract-background: #292929;
-  --alt-heading-font-weight: bold;
-  --color-aliases-static-palette-text-tertiary: #98a2b3;
-  --link-highlight-color: #9184f1;
-}
-
 .aa-Source[data-autocomplete-source-id="filters"] .aa-List .aa-Item:empty {
   display: none !important;
 }
@@ -119,6 +88,7 @@ html[data-theme=dark] {
 }
 
 :root {
+  --body-background: var(--color-white);
   --search-hits-boxshadow: 0 0 0 1px rgba(16, 24, 40, 0.05), 0 1px 3px 0 rgba(16, 24, 40, 0.15);
   --search-detached-mode-background: #fcfcfd;
   --search-icon-color: #667085;
@@ -131,6 +101,7 @@ html[data-theme=dark] {
 }
 
 html[data-theme=dark] {
+  --body-background: #101828;
   --search-hits-boxshadow: 0 0 0 1px rgba(255, 255, 255, 0.05), 0 1px 3px 0 rgba(255, 255, 255, 0.15);
   --search-detached-mode-background: #101828;
   --search-icon-color: #d0d5dd;


### PR DESCRIPTION
Adds the missing CSS variables to fix the background color of the search filter dropdown.

Before:
<img width="545" height="515" alt="2025-09-15_11-50-02" src="https://github.com/user-attachments/assets/d66d5e7a-d5fc-4eb9-901d-9a69f5561d6c" />
